### PR TITLE
Fix frontend: status bubble color, auto-launch backend, dead code

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,7 +1,0 @@
-const { contextBridge, ipcRenderer } = require('electron');
-
-contextBridge.exposeInMainWorld('sparkAPI', {
-  onListen: (callback) => ipcRenderer.on('trigger-listen', callback),
-  //onTranscription: (callback) => ipcRenderer.on('transcription', callback),
-  onGPTResponse: (callback) => ipcRenderer.on('gpt-response', callback)
-});

--- a/public/style.css
+++ b/public/style.css
@@ -28,19 +28,19 @@
 }
 
 /* Listening status: green pulse */
-.listening {
+#bubble.listening {
   background-color: #4CAF50;
   animation: pulse-listening 2s infinite;
 }
 
 /* Thinking status: blue pulse */
-.thinking {
+#bubble.thinking {
   background-color: #2196F3;
   animation: pulse-thinking 1.5s infinite;
 }
 
 /* Speaking status: yellow ripple */
-.speaking {
+#bubble.speaking {
   background-color: #FFC107;
   animation: ripple-speaking 2s infinite;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -74,7 +74,14 @@ function resetSparkOutput() {
 function startSparkBackend() {
   if (!sparkProcess) {
     console.log('[Spark Main] 🚀 Starting backend...');
-    sparkProcess = spawn('python3', ['backend/spark_whisper_mic.py']);
+    const backendDir = path.join(__dirname, '..', 'backend');
+    const pythonPath = path.join(backendDir, 'whisper-env', 'bin', 'python');
+    // cwd must be backendDir: spark_whisper_mic.py's load_dotenv() resolves
+    // .env relative to the process's working directory, not the script path.
+    // "arch -arm64" forces native execution: this Electron/Node install runs
+    // under Rosetta on Apple Silicon, and a translated (x86_64) parent spawns
+    // children in x86_64 by default, which crashes torch (installed arm64-only).
+    sparkProcess = spawn('arch', ['-arm64', pythonPath, 'spark_whisper_mic.py'], { cwd: backendDir });
 
     sparkProcess.stdout.on('data', (data) => {
       console.log(`[Spark] ${data}`);
@@ -92,20 +99,16 @@ function startSparkBackend() {
 }
 
 app.whenReady().then(() => {
-  resetSparkOutput();  // 🧹 very good!
+  resetSparkOutput();
   createWindow();
-
-  // globalShortcut.register('CommandOrControl+Shift+S', () => {
-  //   win.reload();
-  // });
-
-  // globalShortcut.register('Space', () => {
-  //   console.log('[Spark Main] 🔥 Spacebar pressed!');
-  //   startSparkBackend();
-  // });
+  startSparkBackend();
 });
 
 app.on('will-quit', () => {
   globalShortcut.unregisterAll();
+  if (sparkProcess) {
+    sparkProcess.kill();
+    sparkProcess = null;
+  }
 });
 


### PR DESCRIPTION
## Summary
- Fixed the status bubble never actually changing color between listening/thinking/speaking — an ID-vs-class CSS specificity bug meant only the glow animation reflected state, not the fill color. Verified live by running the app and toggling states.
- Wired up `startSparkBackend()` in `src/main.js` — it was previously dead code (only reachable from a commented-out keyboard shortcut), so launching the Electron app did nothing but show an idle bubble; you had to manually start the Python backend yourself.
- Backend spawn now uses the `whisper-env` virtualenv's Python (system `python3` doesn't have whisper/torch installed) and sets `cwd` to `backend/` so `.env` loads correctly.
- Forces `arch -arm64` on the spawned process: this machine's Node.js install is x86_64 running under Rosetta, so it was spawning the backend in x86_64 by default, crashing on the arm64-only torch build. This works around it without needing a Node reinstall.
- Backend process now gets killed on app quit instead of orphaned.
- Deleted `preload.js` — its `contextBridge`/`sparkAPI` setup was never wired into `main.js` and fully unreferenced elsewhere.

## Test plan
- [x] Ran `npm run start`, confirmed backend auto-launches, calibrates, and starts listening without any manual terminal step.
- [x] Verified live via screenshot that the bubble turns green while `status: "listening"` (previously stayed purple in every state).
- [x] Reviewer: run `npm run start` and confirm the full app (bubble + backend) comes up from a single command.

Note: this branch is based on `main`, independent of #14 (backend fixes) — safe to review/merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)