### PR TITLE
Switch transcription engine to mlx-whisper for better accuracy

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-openai-whisper==20250625
+mlx-whisper==0.4.3
 sounddevice==0.5.5
 numpy==2.4.6
 anthropic==0.116.0

--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -3,10 +3,9 @@ import subprocess
 import functools
 import threading
 import queue
-import whisper
+import mlx_whisper
 import sounddevice as sd
 import numpy as np
-import warnings
 import os
 import signal
 import sys
@@ -101,12 +100,20 @@ def calibrate_vad_threshold(duration=2.0):
 def run_speak(text):
     speak(text)
 
-warnings.filterwarnings("ignore", category=UserWarning, module='whisper.transcribe')
 print = functools.partial(print, flush=True)
 
+# mlx-whisper runs on Apple Silicon's GPU (via Metal), letting us use a much
+# bigger, more accurate model than the old CPU-only openai-whisper setup for
+# comparable latency. The prompt below biases decoding toward vocabulary that
+# general-purpose Whisper models otherwise consistently mis-hear (proper
+# nouns and uncommon names aren't well represented in training data).
+MLX_MODEL_REPO = "mlx-community/whisper-large-v3-turbo"
+VOCAB_PROMPT = "Vivek Kamisetty, Claude, Anthropic, Spark, Whisper."
+
 ws_server.start()
-model = whisper.load_model("small.en")
 sample_rate = 16000
+print("[Spark] Warming up mlx-whisper model...")
+mlx_whisper.transcribe(np.zeros(sample_rate, dtype=np.float32), path_or_hf_repo=MLX_MODEL_REPO)
 block_duration = 1.0
 vad_threshold = calibrate_vad_threshold()
 max_silence_time = 1.0
@@ -207,7 +214,11 @@ def mic_listener(transcript_queue):
                 continue
 
             print(f"[Spark] Captured {len(audio_data)} samples, running Whisper...")
-            result = model.transcribe(audio_data, language="en")
+            result = mlx_whisper.transcribe(
+                audio_data,
+                path_or_hf_repo=MLX_MODEL_REPO,
+                initial_prompt=VOCAB_PROMPT,
+            )
             print(f"[Whisper Result] {result}")
 
             text = result["text"].strip()


### PR DESCRIPTION
## Summary
- Replaces `openai-whisper`'s CPU-only `small.en` model with `mlx-whisper` (`large-v3-turbo`), which runs on Apple Silicon's GPU via Metal — a much more capable model at comparable latency, rather than just bumping to `medium.en` on the old engine (tested and found strictly worse: 2x+ slower, no accuracy improvement).
- Adds an `initial_prompt` vocabulary hint to fix a real, reproducible bug: all three tested setups consistently mis-transcribed uncommon proper nouns (the user's name, "Claude") the same way, because general Whisper models default to more common phonetically-similar words without a hint. Confirmed working live across multiple real exchanges.
- `mlx_whisper.transcribe()`'s return shape is a drop-in match for what the existing hallucination filters already expect (`text` + `segments` with `no_speech_prob`/`temperature`) — no changes needed there.
- Added a one-time warm-up call at startup so the first real utterance isn't slowed down by loading the model into memory.
- Removed the now-dead `openai-whisper` dependency and a stale warning filter that referenced its module.

## Test plan
- [x] Empirical side-by-side benchmark of `small.en` vs `medium.en` vs `mlx-whisper` on identical audio clips (recorded live), comparing accuracy and speed.
- [x] Live end-to-end testing across multiple real conversations, including a full multi-turn calendar-scheduling flow with several tool calls — confirms no regression from the Phase 0 WebSocket work or the tool-call reliability fixes.
- [x] `pytest backend/tests/` — 9/9 pass.
- [ ] Reviewer: run `npm run start` and try saying your own name or "Claude" to confirm the vocabulary prompt fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)