### PR TITLE
Phase 1: SQLite session persistence

### DIFF
--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -16,8 +16,15 @@ from claude_client import route_claude_reply as route_gpt_reply
 from tts import speak
 import ws_server
 import protocol
+import store
 should_listen = True  # Global flag to pause listening during TTS
 import signal
+
+# Set once main() starts a session; cleanup_before_exit() needs them to close
+# the session out cleanly on shutdown, but doesn't have direct access to
+# main()'s local variables.
+_db = None
+_session_id = None
 
 def write_status(status, text="", show_popup=False):
     # "inactive" predates the v2 spec's state enum; it means the same thing
@@ -70,6 +77,8 @@ def cleanup_before_exit():
         unmute_microphone()
     except Exception as e:
         print(f"[Spark] ⚠️ Failed to unmute: {e}")
+    if _db is not None and _session_id is not None:
+        store.end_session(_db, _session_id)
     write_status("inactive")
 
 atexit.register(cleanup_before_exit)
@@ -245,10 +254,61 @@ def mic_listener(transcript_queue):
             else:
                 print("[Whisper] No valid text transcribed.")
 
+def speak_reply(text, show_popup=False):
+    """Speak a reply and handle the mic mute/unmute dance around it. Shared by
+    the normal conversation flow and the clear-history confirmation prompts
+    below, which need the exact same TTS-safety handling.
+    """
+    write_status("speaking", text=text, show_popup=show_popup)
+
+    global should_listen
+    should_listen = False  # Stop listening during TTS
+    mute_microphone()
+    speak(text)
+    # Small safety buffer for audio hardware drain after speak() returns.
+    # speak() already blocks for the full utterance via runAndWait(), so
+    # this isn't scaled by reply length — it only covers residual lag
+    # between the TTS engine reporting "done" and the speaker actually
+    # finishing output.
+    time.sleep(0.5)
+
+    # Discard any audio blocks that leaked in while muted (e.g. TTS bleed)
+    # so they aren't mistaken for the next real utterance.
+    while not q.empty():
+        try:
+            q.get_nowait()
+        except queue.Empty:
+            break
+
+    unmute_microphone()
+    should_listen = True  # Resume listening
+    # mic_listener's own loop only re-broadcasts "listening" once it next
+    # breaks out of its capture loop, which can't happen while should_listen
+    # was False — so the state would otherwise be stuck showing "speaking"
+    # until fresh audio nudges it. Send it here explicitly instead of relying
+    # on that side effect.
+    write_status("listening")
+
+
+CLEAR_HISTORY_PHRASES = {"clear history", "clear my history", "clear the history"}
+CONFIRM_PHRASES = {"yes", "yeah", "yep", "confirm", "do it", "sure", "go ahead"}
+
+
 def main():
     print("[Spark] Starting up with VAD and hotkeys...")
     unmute_microphone()
-    chat_history = []
+
+    global _db, _session_id
+    _db = store.init_db()
+    _session_id = store.start_session(_db)
+    chat_history = store.load_recent_messages(_db, limit=20)
+
+    # This is deliberately a small, one-off yes/no state machine, not a
+    # general confirmation system — Phase 4 builds that (reusing the
+    # confirmation_request/confirmation_response protocol messages already
+    # defined in Phase 0) and this gets replaced with it then.
+    pending_clear_confirmation = False
+
     transcript_queue = queue.Queue()
     threading.Thread(target=mic_listener, args=(transcript_queue,), daemon=True).start()
 
@@ -258,6 +318,33 @@ def main():
         if not transcript_queue.empty():
             line = transcript_queue.get().strip()
             normalized_line = line.lower().strip()
+            # Whisper reliably appends sentence punctuation ("clear history."),
+            # so exact-match phrase checks below compare against this stripped
+            # form rather than normalized_line directly — otherwise none of
+            # them would ever match real transcribed speech.
+            stripped_line = normalized_line.strip(".,!?")
+
+            if pending_clear_confirmation:
+                pending_clear_confirmation = False
+                if stripped_line in CONFIRM_PHRASES:
+                    store.clear_history(_db)
+                    chat_history.clear()
+                    print("[Spark] 🧹 Conversation history cleared.")
+                    speak_reply("Done — I've cleared your conversation history.")
+                else:
+                    speak_reply("Okay, I won't clear anything.")
+                start_idle_timer(45)
+                continue
+
+            if stripped_line in CLEAR_HISTORY_PHRASES:
+                pending_clear_confirmation = True
+                cancel_idle_timer()
+                speak_reply("Are you sure you want to clear your conversation history? Say yes to confirm.")
+                # speak_reply() ends in "listening" for the normal case, but
+                # we're now specifically waiting on a yes/no — the protocol
+                # already has a state for exactly this.
+                write_status("awaiting_confirmation")
+                continue
 
             # ✅ Ignore empty/noise-only transcriptions (e.g. just punctuation)
             cleaned_words = [w.strip(".,!?") for w in normalized_line.split()]
@@ -272,7 +359,7 @@ def main():
                 "thank you", "thanks", "i'm sorry", "sorry", "ok", "okay", "cool", "yep", "yes", "no", "all right"
             }
 
-            if normalized_line in polite_phrases:
+            if stripped_line in polite_phrases:
                 print(f"[Spark] 🙏 Ignored polite-only phrase: '{line}'")
                 write_status("listening")
                 continue
@@ -280,6 +367,7 @@ def main():
             # ✅ Process prompt
             print(f"[Spark] [User] {line}")
             chat_history.append({"role": "user", "content": line})
+            store.add_message(_db, _session_id, "user", line)
 
             write_status("thinking")
             cancel_idle_timer()
@@ -287,41 +375,18 @@ def main():
 
             print(f"[Spark] [GPT] {reply}")
             chat_history.append({"role": "assistant", "content": reply})
+            store.add_message(_db, _session_id, "assistant", reply)
+            if tools_called:
+                store.add_message(_db, _session_id, "tool", f"Used tools: {', '.join(tools_called)}")
 
             is_multiline = reply.count("\\n") >= 3 or len(reply.splitlines()) >= 3
             show_popup = model_used == "gpt-4o" or is_multiline
 
-            write_status("speaking", text=reply, show_popup=show_popup)
-
-            global should_listen
-            should_listen = False  # Stop listening during TTS
-            mute_microphone()
-            speak(reply)
-            # Small safety buffer for audio hardware drain after speak() returns.
-            # speak() already blocks for the full utterance via runAndWait(), so
-            # this isn't scaled by reply length — it only covers residual lag
-            # between the TTS engine reporting "done" and the speaker actually
-            # finishing output.
-            time.sleep(0.5)
-
-            # Discard any audio blocks that leaked in while muted (e.g. TTS bleed)
-            # so they aren't mistaken for the next real utterance.
-            while not q.empty():
-                try:
-                    q.get_nowait()
-                except queue.Empty:
-                    break
-
-            unmute_microphone()
-            should_listen = True  # Resume listening
-            # mic_listener's own loop only re-broadcasts "listening" once it
-            # next breaks out of its capture loop, which can't happen while
-            # should_listen was False — so the state would otherwise be stuck
-            # showing "speaking" until fresh audio nudges it. Send it here
-            # explicitly instead of relying on that side effect.
-            write_status("listening")
+            speak_reply(reply, show_popup=show_popup)
             start_idle_timer(45)
 
+            # Bounds Claude's context window only — the database keeps the
+            # full history regardless of what's trimmed from memory here.
             if len(chat_history) > 20:
                 chat_history = chat_history[-18:]
         else:

--- a/backend/store.py
+++ b/backend/store.py
@@ -1,0 +1,106 @@
+"""SQLite-backed session/message persistence (Phase 1 of docs/SPARK_V2_SPEC.md).
+
+Only ever call these functions from spark_whisper_mic.py's main() thread —
+sqlite3 connections aren't safe to share across threads, and nothing here
+needs to run from mic_listener or the WebSocket server thread.
+"""
+
+import os
+import sqlite3
+import time
+
+DEFAULT_DB_PATH = os.path.expanduser("~/.spark/spark.db")
+
+
+def init_db(db_path: str = DEFAULT_DB_PATH) -> sqlite3.Connection:
+    """Open (creating if needed) the database and ensure the schema exists."""
+    if db_path != ":memory:":
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            started_at REAL NOT NULL,
+            ended_at REAL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    # Schema only for now — populated starting in Phase 5's semantic memory work.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memories (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            content TEXT NOT NULL,
+            source_session_id INTEGER,
+            created_at REAL NOT NULL,
+            embedding BLOB
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def start_session(conn: sqlite3.Connection) -> int:
+    cur = conn.execute("INSERT INTO sessions (started_at) VALUES (?)", (time.time(),))
+    conn.commit()
+    return cur.lastrowid
+
+
+def end_session(conn: sqlite3.Connection, session_id: int) -> None:
+    conn.execute("UPDATE sessions SET ended_at = ? WHERE id = ?", (time.time(), session_id))
+    conn.commit()
+
+
+def add_message(conn: sqlite3.Connection, session_id: int, role: str, content: str) -> None:
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, created_at) VALUES (?, ?, ?, ?)",
+        (session_id, role, content, time.time()),
+    )
+    conn.commit()
+
+
+def load_recent_messages(conn: sqlite3.Connection, limit: int = 20) -> list:
+    """Last `limit` conversational turns across recent sessions, chronological,
+    safe to feed straight to Claude as chat_history.
+
+    Two things this deliberately guards against, since Claude's API requires
+    strict user/assistant alternation (see the duplicate-message bug fixed in
+    PR #14 — this is the same class of bug):
+    - 'tool' rows (tool-call summaries, logged for history but not a real
+      conversational turn) are excluded entirely.
+    - the LIMIT window can land on an odd boundary — e.g. starting mid-pair,
+      or ending on a user message with no assistant reply yet persisted
+      (crash, or the reload just happened to land there). Both ends are
+      trimmed until the sequence starts on 'user' and ends on 'assistant'.
+    """
+    rows = conn.execute(
+        "SELECT role, content FROM messages WHERE role IN ('user', 'assistant') "
+        "ORDER BY created_at DESC LIMIT ?",
+        (limit,),
+    ).fetchall()
+    rows.reverse()
+
+    while rows and rows[0][0] != "user":
+        rows.pop(0)
+    while rows and rows[-1][0] != "assistant":
+        rows.pop()
+
+    return [{"role": role, "content": content} for role, content in rows]
+
+
+def clear_history(conn: sqlite3.Connection) -> None:
+    conn.execute("DELETE FROM messages")
+    conn.commit()

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -1,0 +1,108 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import store
+
+
+def make_db():
+    # In-memory DB, isolated per test — never touches the user's real
+    # ~/.spark/spark.db.
+    return store.init_db(":memory:")
+
+
+def test_init_db_creates_tables():
+    conn = make_db()
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert {"sessions", "messages", "memories"} <= tables
+
+
+def test_session_lifecycle():
+    conn = make_db()
+    session_id = store.start_session(conn)
+    row = conn.execute("SELECT started_at, ended_at FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    assert row[0] is not None
+    assert row[1] is None
+
+    store.end_session(conn, session_id)
+    row = conn.execute("SELECT ended_at FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    assert row[0] is not None
+
+
+def test_add_and_load_recent_messages():
+    conn = make_db()
+    session_id = store.start_session(conn)
+    store.add_message(conn, session_id, "user", "hello")
+    store.add_message(conn, session_id, "assistant", "hi there")
+    store.add_message(conn, session_id, "user", "what time is it")
+    store.add_message(conn, session_id, "assistant", "3pm")
+
+    history = store.load_recent_messages(conn, limit=20)
+    assert history == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+        {"role": "user", "content": "what time is it"},
+        {"role": "assistant", "content": "3pm"},
+    ]
+
+
+def test_load_recent_messages_excludes_tool_rows():
+    conn = make_db()
+    session_id = store.start_session(conn)
+    store.add_message(conn, session_id, "user", "check my calendar")
+    store.add_message(conn, session_id, "tool", "Used tools: execute_shell_command")
+    store.add_message(conn, session_id, "assistant", "nothing today")
+
+    history = store.load_recent_messages(conn, limit=20)
+    assert history == [
+        {"role": "user", "content": "check my calendar"},
+        {"role": "assistant", "content": "nothing today"},
+    ]
+
+
+def test_load_recent_messages_trims_dangling_leading_assistant():
+    conn = make_db()
+    session_id = store.start_session(conn)
+    # Simulate a window (limit=1) landing mid-pair: only the assistant half
+    # of the first exchange would be visible without trimming.
+    store.add_message(conn, session_id, "user", "first question")
+    store.add_message(conn, session_id, "assistant", "first answer")
+    store.add_message(conn, session_id, "user", "second question")
+    store.add_message(conn, session_id, "assistant", "second answer")
+
+    history = store.load_recent_messages(conn, limit=3)
+    # Limit=3 grabs [first answer, second question, second answer]; the
+    # leading assistant-only row must get trimmed so it starts on 'user'.
+    assert history == [
+        {"role": "user", "content": "second question"},
+        {"role": "assistant", "content": "second answer"},
+    ]
+
+
+def test_load_recent_messages_trims_dangling_trailing_user():
+    conn = make_db()
+    session_id = store.start_session(conn)
+    store.add_message(conn, session_id, "user", "answered question")
+    store.add_message(conn, session_id, "assistant", "an answer")
+    store.add_message(conn, session_id, "user", "unanswered question")
+
+    history = store.load_recent_messages(conn, limit=20)
+    assert history == [
+        {"role": "user", "content": "answered question"},
+        {"role": "assistant", "content": "an answer"},
+    ]
+
+
+def test_clear_history():
+    conn = make_db()
+    session_id = store.start_session(conn)
+    store.add_message(conn, session_id, "user", "hello")
+    store.add_message(conn, session_id, "assistant", "hi")
+
+    store.clear_history(conn)
+
+    assert store.load_recent_messages(conn) == []


### PR DESCRIPTION
## Summary
Implements Phase 1 of `docs/SPARK_V2_SPEC.md`: cross-restart conversation memory.

- `backend/store.py` — stdlib `sqlite3`, DB at `~/.spark/spark.db`. Three tables (`sessions`, `messages`, `memories` — the last one schema-only until Phase 5). Only ever called from `main()`'s thread, since sqlite3 connections aren't safe to share across threads.
- `load_recent_messages()` guards against the same class of bug fixed in #14 (Claude's API requires strict user/assistant alternation): excludes `tool`-role rows entirely, and trims both ends of the reload window so it always starts on `user` and ends on `assistant` even at an odd `LIMIT` boundary. Covered by dedicated tests.
- `spark_whisper_mic.py` seeds `chat_history` from the last 20 stored messages on startup, persists every turn (plus a tool-call summary line), and closes the session on shutdown.
- New "clear history" voice command, gated behind a spoken yes/no confirmation — a deliberately temporary stand-in until Phase 4 builds the general confirmation system (reusing the `confirmation_request`/`confirmation_response` protocol messages already defined in Phase 0).
- Extracted a `speak_reply()` helper for the mute/speak/unmute dance, shared by the normal flow and the new confirmation prompts instead of duplicating it.

## Bug found and fixed during testing
The clear-history trigger and its yes/no confirmation compared against Whisper's raw transcript directly, which reliably includes trailing punctuation (`"clear history."`). Neither ever matched the phrase sets, so the feature silently no-op'd — falling through to a normal conversational turn where Claude just narrated a fake "sure, cleared!" without anything actually being wiped. Fixed by comparing against a punctuation-stripped form; the same latent bug was in the pre-existing polite-phrase filter too and got fixed there while in the area.

## Test plan
- [x] `pytest backend/tests/` — 16/16 pass, including dedicated cases for both message-alternation trim edge cases.
- [x] Live: stated a fact, fully quit and relaunched the app, asked Spark to recall it — correct, from the restored database.
- [x] Live: "clear history" → confirmed with "yes" → verified the real `store.clear_history()` call fired (not just a spoken reply) → follow-up question about the same fact genuinely failed to recall it.
- [ ] Reviewer: run `npm run start`, have a conversation, quit, relaunch, and confirm it remembers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)