### PR TITLE
Fix orphaned backend process when Spark is quit

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -54,6 +54,8 @@ ipcMain.on('set-mouse-events', (event, interactive) => {
 });
 
 
+let quitting = false;
+
 function startSparkBackend() {
   if (!sparkProcess) {
     console.log('[Spark Main] 🚀 Starting backend...');
@@ -77,8 +79,31 @@ function startSparkBackend() {
     sparkProcess.on('close', (code) => {
       console.log(`[Spark] exited with code ${code}`);
       sparkProcess = null;
+      // The backend dying (crash or otherwise) leaves a UI with nothing
+      // behind it — quit the whole app rather than leaving a zombie window,
+      // matching the same "if one dies, everything dies" lifecycle as the
+      // reverse direction below.
+      if (!quitting) {
+        quitting = true;
+        app.quit();
+      }
     });
   }
+}
+
+function killSparkBackend() {
+  if (!sparkProcess) return;
+  const proc = sparkProcess;
+  // kill() sends SIGTERM, which spark_whisper_mic.py's own handler normally
+  // catches and exits cleanly on — but we've seen it not always respond
+  // promptly (e.g. mid-blocking-call). Escalate to SIGKILL if it hasn't
+  // actually exited after a short grace period, so a hung backend can never
+  // outlive the app and squat on the WebSocket port for the next launch.
+  proc.kill();
+  const forceKillTimer = setTimeout(() => {
+    if (sparkProcess === proc) proc.kill('SIGKILL');
+  }, 3000);
+  proc.once('exit', () => clearTimeout(forceKillTimer));
 }
 
 app.whenReady().then(() => {
@@ -86,11 +111,21 @@ app.whenReady().then(() => {
   startSparkBackend();
 });
 
+// macOS doesn't quit an app when its last window is closed by default — it
+// stays running in the background with the Python backend still alive,
+// which then squats on the WebSocket port when you try to relaunch. Force
+// a real quit instead, since Spark isn't meant to be a background/menu-bar
+// app today.
+app.on('window-all-closed', () => {
+  app.quit();
+});
+
+app.on('before-quit', () => {
+  quitting = true;
+  killSparkBackend();
+});
+
 app.on('will-quit', () => {
   globalShortcut.unregisterAll();
-  if (sparkProcess) {
-    sparkProcess.kill();
-    sparkProcess = null;
-  }
 });
 


### PR DESCRIPTION
## Summary
- Closing the Electron window doesn't quit the app on macOS by default, so the Python backend was left running orphaned in the background — then squatted on the WebSocket port and broke the next launch's WS server (hit live during Phase 1 testing).
- Added `window-all-closed` → `app.quit()`.
- `killSparkBackend()` escalates to SIGKILL after a 3s grace period if the initial `kill()` (SIGTERM) doesn't take — we've seen the Python process not always respond to SIGTERM promptly.
- Lifecycle is now symmetric: the backend dying also quits the app, not just the reverse.

## Test plan
- [x] Launched the app, sent the standard quit Apple Event (same path as Cmd+Q / window-all-closed), confirmed via `ps`/`pgrep` that both the Electron process and the Python backend exited with no orphan left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)