### PR TITLE
Phase 4: agentic confirmation gates for risky shell commands

### DIFF
--- a/backend/claude_client.py
+++ b/backend/claude_client.py
@@ -8,6 +8,8 @@ from dotenv import load_dotenv
 
 import ws_server
 import protocol
+import confirmation_gate
+import risk_classifier
 from sentence_splitter import split_into_sentences
 
 load_dotenv()
@@ -74,8 +76,29 @@ TOOLS = [
 ]
 
 
-def execute_shell_command(command: str) -> str:
-    """Execute a shell command and return output."""
+def execute_shell_command(command: str, on_sentence=None) -> str:
+    """Execute a shell command and return output. Commands not confidently
+    recognized as safe (risk_classifier.py) require confirmation first —
+    declined or timed-out confirmations are not run at all. This is the gate
+    that was missing entirely before Phase 4: earlier in this project, a
+    misheard "yes" let Claude use this exact tool to kill Spark's own
+    Electron process with zero confirmation.
+
+    on_sentence, if given, is the same streaming callback used for regular
+    replies (see route_claude_reply) — passing it through here rather than
+    speaking separately means the confirmation prompt is fed through the one
+    active TTS consumer instead of opening a second, concurrent one.
+    """
+    if risk_classifier.needs_confirmation(command):
+        confirmed = confirmation_gate.request_confirmation(
+            f"Should I run this: {command}",
+            risk="high",
+            options=["Yes", "No"],
+            speak_fn=on_sentence,
+        )
+        if not confirmed:
+            return f"Not run — the user did not confirm: {command}"
+
     try:
         result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=SHELL_COMMAND_TIMEOUT)
         return result.stdout[:500] if result.stdout else result.stderr[:500]
@@ -127,10 +150,10 @@ def _tool_summary(tool_name: str, tool_input: dict) -> str:
     return tool_name
 
 
-def process_tool_call(tool_name: str, tool_input: dict) -> str:
+def process_tool_call(tool_name: str, tool_input: dict, on_sentence=None) -> str:
     """Route tool calls to the appropriate handler."""
     if tool_name == "execute_shell_command":
-        return execute_shell_command(tool_input.get("command", ""))
+        return execute_shell_command(tool_input.get("command", ""), on_sentence=on_sentence)
     elif tool_name == "search_files":
         return search_files(
             tool_input.get("pattern", ""),
@@ -145,7 +168,12 @@ def process_tool_call(tool_name: str, tool_input: dict) -> str:
 def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool = False, on_sentence=None) -> tuple:
     """
     Route a prompt through Claude with tool use.
-    Returns (response_text, model_used, tools_called)
+    Returns (response_text, model_used, tools_called, tool_calls_log)
+
+    tools_called is a flat list of tool names (kept as-is for existing
+    callers); tool_calls_log is the richer per-call detail — name, summary,
+    and actual result — needed to log real commands + results to SQLite
+    rather than just which tool names were used (Phase 4).
 
     If on_sentence is given, it's called with each sentence of the reply as
     soon as it's available (streamed from the API), instead of only once
@@ -158,6 +186,7 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
     model = "claude-sonnet-5"
     requires_image = False
     tools_called = []
+    tool_calls_log = []
 
     # Check if screenshot is needed (simple heuristic for now)
     visual_keywords = [
@@ -335,9 +364,10 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
 
                 print(f"[Claude] 🔧 Calling tool: {tool_name}")
                 ws_server.broadcast(protocol.tool_activity_message(tool_name, "running", summary))
-                tool_result = process_tool_call(tool_name, tool_input)
+                tool_result = process_tool_call(tool_name, tool_input, on_sentence=on_sentence)
                 print(f"[Claude] 📤 Tool result: {tool_result[:100]}...")
                 ws_server.broadcast(protocol.tool_activity_message(tool_name, "done", summary))
+                tool_calls_log.append({"name": tool_name, "summary": summary, "result": tool_result})
 
                 tool_results.append({
                     "type": "tool_result",
@@ -365,7 +395,7 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
             )
             if on_sentence:
                 on_sentence(fallback)
-            return fallback, model, tools_called
+            return fallback, model, tools_called, tool_calls_log
 
         final_text = "".join(full_text_pieces)
         if not final_text:
@@ -373,11 +403,11 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
             if on_sentence:
                 on_sentence(final_text)
 
-        return final_text, model, tools_called
+        return final_text, model, tools_called, tool_calls_log
 
     except Exception as e:
         print(f"[Claude] Error: {e}")
         error_text = f"Sorry, there was a problem: {str(e)}"
         if on_sentence:
             on_sentence(error_text)
-        return error_text, model, tools_called
+        return error_text, model, tools_called, tool_calls_log

--- a/backend/confirmation_gate.py
+++ b/backend/confirmation_gate.py
@@ -87,16 +87,15 @@ def _resolve(answer: str):
     return None
 
 
-# Found live: speak_fn (on_sentence) just enqueues text for the one active
-# TTS consumer and returns immediately — it does NOT block until that text
-# has actually finished playing. Starting the response-timeout clock right
-# after calling it meant the clock was already running (and silently
-# consuming several seconds of it) while the prompt itself was still being
-# synthesized and spoken, before the user had even heard the question yet.
-# There's no cheap way to know exactly when Kokoro finishes a given chunk
-# from here, so this estimates it from word count instead — approximate is
-# fine, the goal is just "don't start the clock before the user could
-# possibly have heard the question," not frame-accurate sync.
+# Fallback only: used when speak_fn doesn't hand back a real completion
+# signal (e.g. it's a fire-and-forget caller with no way to report one).
+# Approximate is fine there — the goal is just "don't start the clock before
+# the user could possibly have heard the question," not frame-accurate sync.
+# Whenever speak_fn hands back a real threading.Event (see request_confirmation
+# below), that's used instead: this estimate has no relationship to actual
+# TTS synthesis/playback time and can elapse well before the prompt has truly
+# finished being spoken — which is exactly what let a fast "yes" resolve (and
+# the command execute) while the prompt was still audibly playing.
 _WORDS_PER_SECOND = 2.5
 
 
@@ -118,7 +117,13 @@ def request_confirmation(prompt, risk="high", options=("Yes", "No"), timeout=DEF
     already mid-stream (like claude_client's tool loop, which already has an
     on_sentence callback feeding the single active TTS consumer) should pass
     that through rather than this module opening a second, concurrent TTS
-    call of its own.
+    call of its own. If speak_fn returns a threading.Event, it's treated as a
+    real "this chunk has actually finished playing" signal and waited on
+    directly instead of guessing from word count — without this, a fast
+    click/voice "yes" could be drained from confirmation_response_queue and
+    acted on (including actually running the command) while the prompt was
+    still audibly speaking, since offer_response()/offer_voice_text() queue a
+    response the instant it arrives, independent of playback.
     """
     global pending_confirmation_id
 
@@ -136,18 +141,26 @@ def request_confirmation(prompt, risk="high", options=("Yes", "No"), timeout=DEF
         confirmation_id, prompt, risk=risk, options=list(options)
     ))
     if speak_fn:
-        speak_fn(prompt)
-        # speak_fn just enqueues the prompt for the one active TTS consumer
-        # and returns immediately — waiting out an estimate of how long it
-        # takes to actually finish being spoken before starting the response
-        # clock below, so the user doesn't lose part of their response
-        # window to a question they hadn't finished hearing yet.
-        time.sleep(_estimate_speaking_seconds(prompt))
-    # Only now, after the prompt has actually (approximately) finished being
-    # spoken, are we truly just sitting and waiting on an answer — broadcast
-    # the state here rather than before speak_fn, since speak_fn's own state
-    # broadcasts (speaking -> listening) would otherwise immediately
-    # overwrite an earlier "awaiting_confirmation".
+        done_event = speak_fn(prompt)
+        if done_event is not None:
+            # Real signal from the TTS engine: wait for this exact chunk to
+            # actually finish playing (or be skipped/interrupted) rather than
+            # guessing. Capped generously so a stuck/never-signaling engine
+            # can't hang the tool call forever — normal playback always sets
+            # this well before the cap.
+            done_event.wait(timeout=max(_estimate_speaking_seconds(prompt) * 4, 15))
+        else:
+            # speak_fn didn't hand back anything to wait on — either nothing
+            # was actually queued for TTS (e.g. muted voice mode), or the
+            # caller already blocked synchronously before returning (e.g.
+            # speak_reply, used by the clear-history flow). Fall back to the
+            # word-count estimate as a safe minimum wait either way.
+            time.sleep(_estimate_speaking_seconds(prompt))
+    # Only now, after the prompt has actually finished being spoken, are we
+    # truly just sitting and waiting on an answer — broadcast the state here
+    # rather than before speak_fn, since speak_fn's own state broadcasts
+    # (speaking -> listening) would otherwise immediately overwrite an
+    # earlier "awaiting_confirmation".
     ws_server.broadcast(protocol.state_message("awaiting_confirmation"))
 
     # Found live (the actual root cause behind voice confirmations never

--- a/backend/confirmation_gate.py
+++ b/backend/confirmation_gate.py
@@ -1,0 +1,186 @@
+"""General-purpose confirmation gate (Phase 4) — shared by spark_whisper_mic.py
+(voice turns, clear-history) and claude_client.py (tool-call risk gating).
+Lives in its own module rather than spark_whisper_mic.py because
+claude_client.py can't import from there without a circular import
+(spark_whisper_mic.py already imports route_claude_reply from claude_client.py).
+
+A confirmation can be resolved by either a chip click (WS confirmation_response,
+routed here by incoming_message_watcher via offer_response) or a spoken
+yes/no (routed here by mic_listener via offer_voice_text whenever a
+confirmation is pending) — first response wins, exactly like the original
+Phase 3 clear-history flow this generalizes.
+"""
+
+import re
+import queue
+import time
+import uuid
+
+import protocol
+import ws_server
+import mic_control
+
+# A whole-word/phrase match resolves things — not requiring the entire
+# utterance to be JUST one of these (that rejected completely reasonable
+# natural phrasings like "Okay, go ahead." — extra words or punctuation
+# meant it never matched anything at all), but still requiring one of these
+# specific words to actually be present, which is what keeps this resistant
+# to unrelated ambient noise or a hallucinated stray word.
+CONFIRM_PHRASES = {"yes", "yeah", "yep", "confirm", "do it", "sure", "go ahead"}
+DECLINE_PHRASES = {"no", "nope", "don't", "do not", "cancel", "stop", "never mind"}
+
+# Per Phase 4 spec: a timeout with no response counts as a decline, not as
+# "keep waiting" or "assume yes" — the safe default when nobody's there to ask.
+DEFAULT_TIMEOUT = 30
+
+pending_confirmation_id = None
+confirmation_response_queue = queue.Queue()
+
+
+def is_pending() -> bool:
+    return pending_confirmation_id is not None
+
+
+def offer_response(id_: str, choice: str) -> bool:
+    """Called by incoming_message_watcher for a WS confirmation_response (a
+    chip click). Returns True if it matched the currently pending
+    confirmation and was queued; False if it's stale/unrelated and should be
+    otherwise ignored.
+    """
+    if id_ == pending_confirmation_id:
+        confirmation_response_queue.put(choice)
+        return True
+    return False
+
+
+def offer_voice_text(text: str) -> bool:
+    """Called by mic_listener for a fresh voice transcript. Returns True if a
+    confirmation was pending and this text was routed here instead of the
+    normal transcript_queue — the caller should skip its normal handling of
+    this transcript in that case, win-or-lose, since it was never a fresh
+    user request in the first place.
+    """
+    if not is_pending():
+        return False
+    confirmation_response_queue.put(text)
+    return True
+
+
+def _matches(normalized: str, phrases: set) -> bool:
+    return any(re.search(rf"\b{re.escape(p)}\b", normalized) for p in phrases)
+
+
+def _resolve(answer: str):
+    """Returns True/False if `answer` clearly confirms or declines, None if
+    it's ambiguous (matches both or neither) and the wait should continue.
+    """
+    # Apostrophes kept deliberately -- DECLINE_PHRASES has "don't", and
+    # stripping it here (word chars/whitespace only) would leave "dont",
+    # which the literal "don't" pattern below would then never match.
+    normalized = re.sub(r"[^\w\s']", "", answer.lower())
+    confirmed = _matches(normalized, CONFIRM_PHRASES)
+    declined = _matches(normalized, DECLINE_PHRASES)
+    if confirmed and not declined:
+        return True
+    if declined and not confirmed:
+        return False
+    return None
+
+
+# Found live: speak_fn (on_sentence) just enqueues text for the one active
+# TTS consumer and returns immediately — it does NOT block until that text
+# has actually finished playing. Starting the response-timeout clock right
+# after calling it meant the clock was already running (and silently
+# consuming several seconds of it) while the prompt itself was still being
+# synthesized and spoken, before the user had even heard the question yet.
+# There's no cheap way to know exactly when Kokoro finishes a given chunk
+# from here, so this estimates it from word count instead — approximate is
+# fine, the goal is just "don't start the clock before the user could
+# possibly have heard the question," not frame-accurate sync.
+_WORDS_PER_SECOND = 2.5
+
+
+def _estimate_speaking_seconds(text: str) -> float:
+    return max(1.0, len(text.split()) / _WORDS_PER_SECOND)
+
+
+def request_confirmation(prompt, risk="high", options=("Yes", "No"), timeout=DEFAULT_TIMEOUT, speak_fn=None):
+    """Blocks the calling thread until the user confirms/declines via voice or
+    a chip click, or `timeout` seconds elapse (timeout counts as a decline).
+    Returns True if confirmed, False otherwise.
+
+    Safe to call from any thread — voice resolution works even when the
+    caller is a background thread with the main loop blocked waiting on it
+    (e.g. mid tool-call), since mic_listener routes voice input here directly
+    rather than relying on whichever loop happens to be free to poll it.
+
+    speak_fn, if given, is called with the prompt text — callers that are
+    already mid-stream (like claude_client's tool loop, which already has an
+    on_sentence callback feeding the single active TTS consumer) should pass
+    that through rather than this module opening a second, concurrent TTS
+    call of its own.
+    """
+    global pending_confirmation_id
+
+    # Drain anything stale left over from a previous confirmation so it can't
+    # be misread as an answer to this one.
+    while not confirmation_response_queue.empty():
+        try:
+            confirmation_response_queue.get_nowait()
+        except queue.Empty:
+            break
+
+    confirmation_id = str(uuid.uuid4())
+    pending_confirmation_id = confirmation_id
+    ws_server.broadcast(protocol.confirmation_request_message(
+        confirmation_id, prompt, risk=risk, options=list(options)
+    ))
+    if speak_fn:
+        speak_fn(prompt)
+        # speak_fn just enqueues the prompt for the one active TTS consumer
+        # and returns immediately — waiting out an estimate of how long it
+        # takes to actually finish being spoken before starting the response
+        # clock below, so the user doesn't lose part of their response
+        # window to a question they hadn't finished hearing yet.
+        time.sleep(_estimate_speaking_seconds(prompt))
+    # Only now, after the prompt has actually (approximately) finished being
+    # spoken, are we truly just sitting and waiting on an answer — broadcast
+    # the state here rather than before speak_fn, since speak_fn's own state
+    # broadcasts (speaking -> listening) would otherwise immediately
+    # overwrite an earlier "awaiting_confirmation".
+    ws_server.broadcast(protocol.state_message("awaiting_confirmation"))
+
+    # Found live (the actual root cause behind voice confirmations never
+    # working): whatever's speaking the prompt already muted the mic on its
+    # first sentence (see spark_whisper_mic.py's on_sentence) and normally
+    # doesn't unmute again until the entire turn including this tool call
+    # finishes — which can't happen until this confirmation resolves. That
+    # left the mic's actual input volume near zero for the whole response
+    # window, so a real spoken "yes" came through as a barely-there, mostly
+    # silent clip that Whisper had no chance of transcribing correctly.
+    # Explicitly unmute for the window where we're actually expecting an
+    # answer, then mute again before returning to restore the "muted during
+    # speech" state for whatever comes next in the turn.
+    mic_control.unmute_microphone()
+
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            try:
+                answer = confirmation_response_queue.get(timeout=remaining)
+            except queue.Empty:
+                return False
+
+            resolution = _resolve(answer)
+            if resolution is not None:
+                return resolution
+            # Anything ambiguous (stray noise, unrelated speech, or a phrase
+            # matching both sets) is ignored and the wait continues within
+            # whatever's left of the deadline.
+    finally:
+        mic_control.mute_microphone()
+        pending_confirmation_id = None
+        ws_server.broadcast(protocol.confirmation_resolved_message(confirmation_id))

--- a/backend/mic_control.py
+++ b/backend/mic_control.py
@@ -1,0 +1,26 @@
+"""Shared microphone mute state (Phase 4) — lives in its own module so
+confirmation_gate.py and claude_client.py can both reach it without a
+circular import through spark_whisper_mic.py (which already imports
+route_claude_reply from claude_client.py).
+
+should_listen gates whether mic_listener's capture loop pays attention to
+anything at all; mute/unmute additionally drive the actual macOS input
+volume, since Spark has no echo cancellation and would otherwise hear its
+own TTS output as if it were the user talking.
+"""
+
+import subprocess
+
+should_listen = True
+
+
+def mute_microphone():
+    global should_listen
+    should_listen = False
+    subprocess.run(['osascript', '-e', 'set volume input volume 0'])
+
+
+def unmute_microphone():
+    global should_listen
+    should_listen = True
+    subprocess.run(['osascript', '-e', 'set volume input volume 100'])

--- a/backend/risk_classifier.py
+++ b/backend/risk_classifier.py
@@ -1,0 +1,77 @@
+"""Allowlist-first risk classification for execute_shell_command (Phase 4).
+
+Per docs/SPARK_V2_SPEC.md's own framing: a blocklist of dangerous patterns
+(rm, sudo, kill, ...) is inherently incomplete — things like `curl | sh`,
+`chmod`, `launchctl`, or a forced `git push` slip through unlisted (this is
+exactly the class of gap that let a misheard "yes" have Claude kill Spark's
+own Electron process earlier in this project, with no gate at all). An
+allowlist instead only auto-runs commands confidently recognized as safe;
+anything else — including anything using shell chaining/redirection, which
+can smuggle risk in through an otherwise-safe base command — asks first.
+"""
+
+import re
+import shlex
+
+# Base binaries considered safe/read-only when used plainly (no shell
+# chaining/redirection below). Deliberately narrow — allowlist-first means
+# anything NOT recognized here defaults to needing confirmation, rather than
+# trying to enumerate every dangerous command instead.
+SAFE_COMMANDS = {
+    "ls", "pwd", "cat", "echo", "date", "whoami", "uname", "hostname",
+    "ps", "df", "du", "top", "uptime", "sw_vers", "sysctl",
+    "find", "grep", "head", "tail", "wc", "file", "stat", "which", "type",
+    "env", "printenv", "id", "groups", "ping",
+}
+
+# find/grep can still modify or exfiltrate with the right flags even though
+# the bare command name looks read-only.
+RISKY_FIND_FLAGS = {"-delete", "-exec", "-execdir", "-fprintf", "-fls"}
+
+# Any of these chain, redirect, substitute, or background a command, which
+# can introduce side effects beyond whatever the base command alone would do
+# (e.g. "curl ... | sh", "ls > /some/file", "cat x; rm y") — present, this
+# always needs confirmation regardless of how safe the base command looks.
+RISKY_SHELL_SYNTAX = re.compile(r"[|;&`$<>]")
+
+# osascript gets its own narrower check rather than a blanket confirmation
+# requirement: Spark is explicitly instructed (see claude_client.py's system
+# prompt) to use it for everyday Calendar/Reminders reads, and requiring
+# confirmation on every single one of those would make normal use annoying.
+# This is a keyword heuristic — same caveat as any blocklist — so anything
+# it can't confidently call read-only defaults to needing confirmation.
+MUTATING_APPLESCRIPT_VERBS = re.compile(
+    r"\b(set|make|delete|remove|move|duplicate|empty|trash|save|do shell script)\b",
+    re.IGNORECASE,
+)
+
+
+def needs_confirmation(command: str) -> bool:
+    """Returns True if `command` should require confirmation before running,
+    False if it's safe to auto-run.
+    """
+    if RISKY_SHELL_SYNTAX.search(command):
+        return True
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        # Unbalanced quotes etc. — can't confidently parse it, so don't
+        # confidently allow it either.
+        return True
+
+    if not tokens:
+        return True
+
+    base = tokens[0]
+
+    if base == "osascript":
+        return bool(MUTATING_APPLESCRIPT_VERBS.search(command))
+
+    if base not in SAFE_COMMANDS:
+        return True
+
+    if base == "find" and any(flag in tokens for flag in RISKY_FIND_FLAGS):
+        return True
+
+    return False

--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -3,7 +3,6 @@ import subprocess
 import functools
 import threading
 import queue
-import uuid
 import mlx_whisper
 import sounddevice as sd
 import numpy as np
@@ -18,8 +17,9 @@ import ws_server
 import protocol
 import store
 import audio_bands
+import confirmation_gate
+import mic_control
 from tts_engine import KokoroTTSEngine, Pyttsx3TTSEngine
-should_listen = True  # Global flag to pause listening during TTS
 import signal
 
 # Set once main() starts a session; cleanup_before_exit() needs them to close
@@ -92,7 +92,7 @@ def cancel_idle_timer():
 def cleanup_before_exit():
     print("[Spark] 🧼 Cleaning up before shutdown...")
     try:
-        unmute_microphone()
+        mic_control.unmute_microphone()
     except Exception as e:
         print(f"[Spark] ⚠️ Failed to unmute: {e}")
     if _db is not None and _session_id is not None:
@@ -154,12 +154,6 @@ max_recording_time = 10.0  # Hard cap so a noisy room can't keep the recorder op
 
 q = queue.Queue()
 
-def mute_microphone():
-    subprocess.run(['osascript', '-e', 'set volume input volume 0'])
-
-def unmute_microphone():
-    subprocess.run(['osascript', '-e', 'set volume input volume 100'])
-
 def audio_callback(indata, frames, time_info, status):
     #print(f"[Audio] callback fired with {len(indata)} frames")
     if status:
@@ -174,6 +168,19 @@ def get_device_id_by_name(name_keyword):
             return i
     print("[Spark] ❌ Mic keyword not found, falling back to default device #0")
     return 0
+
+# Whisper reliably hallucinates these exact filler words on quiet/noisy
+# clips with no real speech in them (see the no_speech_prob/temperature
+# checks below for the more reliable signal this backs up). Shared at
+# module level so mic_listener can skip ever displaying one as a fake user
+# turn, not just skip acting on it once it's already in transcript_queue —
+# broadcasting it first and filtering later meant a stray "Thank you." could
+# wipe the panel's now-latest-exchange-only view of a real conversation
+# with nothing, since nothing ever replies to it.
+POLITE_PHRASES = {
+    "thank you", "thanks", "i'm sorry", "sorry", "ok", "okay", "cool", "yep", "yes", "no", "all right"
+}
+
 
 def mic_listener(transcript_queue):
     try:
@@ -212,13 +219,26 @@ def mic_listener(transcript_queue):
                     ws_server.broadcast(protocol.amplitude_message("mic", bass, mid, high))
                     last_amplitude_broadcast = now
 
-                if max_amplitude > vad_threshold and should_listen:  # Add "and should_listen" here
+                if max_amplitude > vad_threshold and mic_control.should_listen:
                     audio_data.append(block)
                     if not speech_detected:
                         speech_start_time = time.time()
                     speech_detected = True
                     silence_timer = None
                 elif speech_detected:
+                    # Found live: short single-syllable words like "yes"/"no"
+                    # (exactly what voice confirmations need) often trail off
+                    # in volume fast enough to dip back under vad_threshold
+                    # well before the word is actually finished — previously
+                    # only over-threshold blocks were appended, so the clip
+                    # got truncated to just the loudest fragment (a handful
+                    # of ms) instead of the whole word, and then got thrown
+                    # out entirely by the "too short to be speech" floor
+                    # below. Keep appending through the quieter tail too,
+                    # for as long as we're still within the silence grace
+                    # period — only actually stop once max_silence_time of
+                    # true silence has passed.
+                    audio_data.append(block)
                     if silence_timer is None:
                         silence_timer = time.time()
                     elif time.time() - silence_timer > max_silence_time:
@@ -235,6 +255,25 @@ def mic_listener(transcript_queue):
                 continue
 
             audio_data = np.concatenate(audio_data, axis=0)
+
+            # Found live: capturing through the full silence grace period
+            # above (fixing short words like "yes" getting truncated to
+            # nothing) means a quick word is now followed by up to a full
+            # second of near-silent tail audio. That padding made the clip
+            # mostly silence by volume, which pushed Whisper toward its
+            # classic hallucination on quiet clips ("Thank you.") instead of
+            # actually transcribing the short word — trim back down to a
+            # small buffer after the last genuinely loud moment.
+            _ANALYSIS_WINDOW = max(1, int(0.05 * sample_rate))  # ~50ms
+            _TRAILING_PAD = int(0.2 * sample_rate)  # keep ~200ms of tail context
+            last_loud_end = 0
+            for i in range(0, len(audio_data), _ANALYSIS_WINDOW):
+                chunk = audio_data[i:i + _ANALYSIS_WINDOW]
+                if len(chunk) and np.max(np.abs(chunk)) > vad_threshold:
+                    last_loud_end = i + len(chunk)
+            if last_loud_end > 0:
+                audio_data = audio_data[: min(len(audio_data), last_loud_end + _TRAILING_PAD)]
+
             max_val = np.max(np.abs(audio_data), axis=0)
             if max_val > 0:
                 audio_data = audio_data / max_val
@@ -272,6 +311,16 @@ def mic_listener(transcript_queue):
                 print(f"[Whisper] Ignored likely hallucination (no_speech_prob={avg_no_speech_prob:.2f}): '{text}'")
             elif max_temperature >= 0.8:
                 print(f"[Whisper] Ignored low-confidence garbled transcription (temperature={max_temperature:.1f}): '{text}'")
+            elif not confirmation_gate.is_pending() and text.strip().lower().strip(".,!?") in POLITE_PHRASES:
+                # Skip displaying this at all, not just skip acting on it —
+                # broadcasting it unconditionally and filtering only once it
+                # reached transcript_queue (as before) meant a stray "Thank
+                # you." still visibly wiped the panel's now-latest-exchange
+                # view of a real conversation, with nothing ever replying to
+                # it. Only applies when nothing's pending: "yes"/"no" must
+                # still get through (and get displayed) to actually resolve a
+                # confirmation — see the branch below.
+                print(f"[Spark] 🙏 Ignored polite-only phrase (not shown): '{text}'")
             elif text:
                 print(f"[User] {text}")
                 # mlx-whisper only produces a full utterance after silence
@@ -279,7 +328,14 @@ def mic_listener(transcript_queue):
                 # is always the final transcript (partial=False) — there's
                 # no true partial/live ASR in this pipeline to stream yet.
                 ws_server.broadcast(protocol.transcript_message("user", text, partial=False))
-                transcript_queue.put(text)
+                # A confirmation (clear-history, or now a tool-call risk gate
+                # running on a background thread) is resolved here directly
+                # rather than via transcript_queue — main()'s own loop isn't
+                # necessarily free to poll it, e.g. while blocked waiting on
+                # a tool call, so this has to work regardless of what else is
+                # going on.
+                if not confirmation_gate.offer_voice_text(text):
+                    transcript_queue.put(text)
             else:
                 print("[Whisper] No valid text transcribed.")
 
@@ -288,7 +344,6 @@ def _post_speech_cleanup():
     interrupted: drain any audio that leaked in while muted, unmute, and
     resume listening.
     """
-    global should_listen
     # Small safety buffer for audio hardware drain. Not needed while the
     # engine is actively synthesizing/playing further chunks, only once
     # speech has actually stopped (natural end or interrupt).
@@ -302,8 +357,7 @@ def _post_speech_cleanup():
         except queue.Empty:
             break
 
-    unmute_microphone()
-    should_listen = True  # Resume listening
+    mic_control.unmute_microphone()
     # mic_listener's own loop only re-broadcasts "listening" once it next
     # breaks out of its capture loop, which can't happen while should_listen
     # was False — so the state would otherwise be stuck showing "speaking"
@@ -320,28 +374,21 @@ def speak_reply(text, show_popup=False):
     """
     write_status("speaking", text=text, show_popup=show_popup)
 
-    global should_listen
-    should_listen = False  # Stop listening during TTS
-    mute_microphone()
+    mic_control.mute_microphone()
     tts_engine.speak_stream(iter([text]))
     _post_speech_cleanup()
-
-
-# Set by main() while a confirmation prompt (e.g. clear-history) is pending,
-# so a confirmation_response WS message (a chip click) can resolve it just
-# like a spoken yes/no — "first response wins" between the two channels, per
-# docs/SPARK_V2_SPEC.md. None whenever nothing is pending, which also makes
-# a stale/late response naturally get ignored below (its id won't match).
-_pending_confirmation_id = None
-confirmation_response_queue = queue.Queue()
 
 
 def incoming_message_watcher(transcript_queue):
     """Watches messages the frontend sends back over the WebSocket:
     - interrupt: tap-to-interrupt (Phase 2) — stop whatever TTS is playing.
     - text_input: typed fallback input — fed into the same queue voice
-      transcripts use, so it's processed identically either way.
-    - confirmation_response: resolves a pending confirmation (see above).
+      transcripts use, so it's processed identically either way, unless a
+      confirmation is pending (see confirmation_gate.py), in which case it
+      resolves that instead of starting a new turn.
+    - confirmation_response: resolves a pending confirmation (a chip click) —
+      see confirmation_gate.py. "First response wins" between a chip click
+      and a spoken/typed yes-or-no, per docs/SPARK_V2_SPEC.md.
     Runs as its own thread since main()'s loop blocks on
     tts_engine.speak_stream() while TTS plays and can't poll this itself.
     """
@@ -362,11 +409,11 @@ def incoming_message_watcher(transcript_queue):
                 # optimistically — one rendering path for both input methods
                 # instead of two that could drift apart.
                 ws_server.broadcast(protocol.transcript_message("user", text, partial=False))
-                transcript_queue.put(text)
+                if not confirmation_gate.offer_voice_text(text):
+                    transcript_queue.put(text)
 
         elif msg_type == "confirmation_response":
-            if msg.get("id") == _pending_confirmation_id:
-                confirmation_response_queue.put(msg.get("choice", ""))
+            confirmation_gate.offer_response(msg.get("id"), msg.get("choice", ""))
 
 
 def process_claude_turn(line, chat_history):
@@ -374,7 +421,7 @@ def process_claude_turn(line, chat_history):
     thread so its streamed sentences can be spoken as they arrive rather than
     waiting for the complete reply, while the calling (main) thread feeds
     those sentences to the TTS engine as they're produced. Returns
-    (reply_text, model_used, tools_called).
+    (reply_text, model_used, tools_called, tool_calls_log).
     """
     sentence_queue = queue.Queue()
     DONE = object()
@@ -390,9 +437,7 @@ def process_claude_turn(line, chat_history):
         if not first_sentence.is_set():
             first_sentence.set()
             write_status("speaking")
-            global should_listen
-            should_listen = False  # Stop listening during TTS
-            mute_microphone()
+            mic_control.mute_microphone()
 
         # The panel always gets the full text (marker stripped) regardless of
         # voice mode — only how much of it also gets queued for TTS depends
@@ -419,12 +464,13 @@ def process_claude_turn(line, chat_history):
             sentence_queue.put((chunk_index, spoken_text))
 
     def run_claude():
-        reply, model_used, tools_called = route_gpt_reply(
+        reply, model_used, tools_called, tool_calls_log = route_gpt_reply(
             line, chat_history, screenshot_enabled=True, on_sentence=on_sentence
         )
         result["reply"] = reply
         result["model_used"] = model_used
         result["tools_called"] = tools_called
+        result["tool_calls_log"] = tool_calls_log
         sentence_queue.put(DONE)
 
     claude_thread = threading.Thread(target=run_claude, daemon=True)
@@ -462,84 +508,28 @@ def process_claude_turn(line, chat_history):
         # sentence streamed) — still need to return to listening.
         write_status("listening")
 
-    return reply, result["model_used"], result["tools_called"]
+    return reply, result["model_used"], result["tools_called"], result["tool_calls_log"]
 
 
 CLEAR_HISTORY_PHRASES = {"clear history", "clear my history", "clear the history"}
-CONFIRM_PHRASES = {"yes", "yeah", "yep", "confirm", "do it", "sure", "go ahead"}
-DECLINE_PHRASES = {"no", "nope", "don't", "do not", "cancel", "stop", "never mind"}
 
 
 def main():
     print("[Spark] Starting up with VAD and hotkeys...")
-    unmute_microphone()
+    mic_control.unmute_microphone()
 
     global _db, _session_id
     _db = store.init_db()
     _session_id = store.start_session(_db)
     chat_history = store.load_recent_messages(_db, limit=20)
 
-    # This is deliberately a small, one-off yes/no state machine for exactly
-    # one command, not a general confirmation system — Phase 4 builds that
-    # (any risky action, not just this one) and this gets replaced with it
-    # then. It does use the real confirmation_request/confirmation_response
-    # protocol messages (defined in Phase 0), retrofitted here in Phase 3 so
-    # the frontend's confirmation chips have something real to resolve.
-    pending_clear_confirmation = False
-
     transcript_queue = queue.Queue()
     threading.Thread(target=mic_listener, args=(transcript_queue,), daemon=True).start()
     threading.Thread(target=incoming_message_watcher, args=(transcript_queue,), daemon=True).start()
 
-    def resolve_clear_confirmation(answer_text):
-        # Found live: an unrelated stray transcript during the confirmation
-        # window (e.g. the mic picking up "thank you") used to be forced
-        # into a decision — treated as an implicit "no" if it didn't
-        # exactly match a yes-phrase. Beyond being annoying, that's a real
-        # safety problem in the other direction too: if ambient noise
-        # happens to produce a word that IS in CONFIRM_PHRASES (like "sure"
-        # or "yeah" — both plausible Whisper hallucinations), a destructive
-        # action could get confirmed without genuine intent. Only an
-        # explicit yes/no phrase resolves anything now; anything else is
-        # ignored and the confirmation stays pending.
-        global _pending_confirmation_id
-        nonlocal pending_clear_confirmation
-        normalized = answer_text.strip(".,!? ").lower()
-
-        if normalized in CONFIRM_PHRASES:
-            resolved_id = _pending_confirmation_id
-            pending_clear_confirmation = False
-            _pending_confirmation_id = None
-            store.clear_history(_db)
-            chat_history.clear()
-            print("[Spark] 🧹 Conversation history cleared.")
-            ws_server.broadcast(protocol.confirmation_resolved_message(resolved_id))
-            speak_reply("Done — I've cleared your conversation history.")
-            start_idle_timer(45)
-        elif normalized in DECLINE_PHRASES:
-            resolved_id = _pending_confirmation_id
-            pending_clear_confirmation = False
-            _pending_confirmation_id = None
-            ws_server.broadcast(protocol.confirmation_resolved_message(resolved_id))
-            speak_reply("Okay, I won't clear anything.")
-            start_idle_timer(45)
-        else:
-            print(f"[Spark] ⏭️ Ignored unrelated input while awaiting confirmation: {answer_text!r}")
-
     write_status("listening")
 
     while True:
-        # Checked before transcript_queue each loop so a chip click can
-        # resolve a pending confirmation exactly as fast as a spoken answer
-        # would — whichever channel produces a response first wins; the
-        # other is naturally ignored once _pending_confirmation_id is
-        # cleared (incoming_message_watcher only queues a response whose id
-        # still matches the currently-pending one).
-        if pending_clear_confirmation and not confirmation_response_queue.empty():
-            choice = confirmation_response_queue.get()
-            resolve_clear_confirmation(choice)
-            continue
-
         if not transcript_queue.empty():
             line = transcript_queue.get().strip()
             normalized_line = line.lower().strip()
@@ -549,26 +539,26 @@ def main():
             # them would ever match real transcribed speech.
             stripped_line = normalized_line.strip(".,!?")
 
-            if pending_clear_confirmation:
-                resolve_clear_confirmation(stripped_line)
-                continue
-
             if stripped_line in CLEAR_HISTORY_PHRASES:
-                pending_clear_confirmation = True
-                global _pending_confirmation_id
-                _pending_confirmation_id = str(uuid.uuid4())
                 cancel_idle_timer()
-                ws_server.broadcast(protocol.confirmation_request_message(
-                    _pending_confirmation_id,
-                    "Are you sure you want to clear your conversation history?",
+                # request_confirmation blocks this loop until resolved (chip
+                # click or spoken/typed yes-no) or it times out — fine here,
+                # since mic_listener routes voice input to it directly and
+                # doesn't need this loop to be free to poll anything.
+                confirmed = confirmation_gate.request_confirmation(
+                    "Are you sure you want to clear your conversation history? Say yes to confirm.",
                     risk="low",
                     options=["Yes", "No"],
-                ))
-                speak_reply("Are you sure you want to clear your conversation history? Say yes to confirm.")
-                # speak_reply() ends in "listening" for the normal case, but
-                # we're now specifically waiting on a yes/no — the protocol
-                # already has a state for exactly this.
-                write_status("awaiting_confirmation")
+                    speak_fn=speak_reply,
+                )
+                if confirmed:
+                    store.clear_history(_db)
+                    chat_history.clear()
+                    print("[Spark] 🧹 Conversation history cleared.")
+                    speak_reply("Done — I've cleared your conversation history.")
+                else:
+                    speak_reply("Okay, I won't clear anything.")
+                start_idle_timer(45)
                 continue
 
             # ✅ Ignore empty/noise-only transcriptions (e.g. just punctuation)
@@ -579,12 +569,9 @@ def main():
                 write_status("listening")
                 continue
 
-            # ✅ Ignore polite phrases
-            polite_phrases = {
-                "thank you", "thanks", "i'm sorry", "sorry", "ok", "okay", "cool", "yep", "yes", "no", "all right"
-            }
-
-            if stripped_line in polite_phrases:
+            # ✅ Ignore polite phrases (typed input only reaches here — voice
+            # input is already filtered earlier, before display, in mic_listener)
+            if stripped_line in POLITE_PHRASES:
                 print(f"[Spark] 🙏 Ignored polite-only phrase: '{line}'")
                 write_status("listening")
                 continue
@@ -596,13 +583,20 @@ def main():
 
             write_status("thinking")
             cancel_idle_timer()
-            reply, model_used, tools_called = process_claude_turn(line, chat_history)
+            reply, model_used, tools_called, tool_calls_log = process_claude_turn(line, chat_history)
 
             print(f"[Spark] [GPT] {reply}")
             chat_history.append({"role": "assistant", "content": reply})
             store.add_message(_db, _session_id, "assistant", reply)
-            if tools_called:
-                store.add_message(_db, _session_id, "tool", f"Used tools: {', '.join(tools_called)}")
+            # Each actual command/call + its real result, not just which tool
+            # names got used — needed to have a real audit trail of what
+            # Spark actually did on this machine, not just that it did
+            # "something" with execute_shell_command at some point.
+            for call in tool_calls_log:
+                store.add_message(
+                    _db, _session_id, "tool",
+                    f"{call['summary']} -> {call['result'][:200]}"
+                )
 
             start_idle_timer(45)
 

--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -461,7 +461,15 @@ def process_claude_turn(line, chat_history):
         if display_text.strip():
             ws_server.broadcast(protocol.assistant_chunk_message(display_text, chunk_index))
         if spoken_text.strip():
-            sentence_queue.put((chunk_index, spoken_text))
+            # Handed back to callers (e.g. confirmation_gate's speak_fn) that
+            # need to know when this specific chunk has actually finished
+            # playing, not just that it was handed to the TTS consumer —
+            # tts_engine sets this once real playback of this chunk
+            # completes (or is skipped/interrupted).
+            done_event = threading.Event()
+            sentence_queue.put((chunk_index, spoken_text, done_event))
+            return done_event
+        return None
 
     def run_claude():
         reply, model_used, tools_called, tool_calls_log = route_gpt_reply(

--- a/backend/tests/test_confirmation_gate.py
+++ b/backend/tests/test_confirmation_gate.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import confirmation_gate as cg
+
+
+def test_exact_phrases_still_resolve():
+    assert cg._resolve("yes") is True
+    assert cg._resolve("no") is False
+    assert cg._resolve("sure") is True
+    assert cg._resolve("cancel") is False
+
+
+def test_natural_phrasing_with_extra_words_resolves():
+    # The original bug report: "Okay, go ahead." didn't match anything under
+    # the old exact-full-string-match rule, silently leaving the
+    # confirmation stuck pending until it timed out.
+    assert cg._resolve("Okay, go ahead.") is True
+    assert cg._resolve("Yes, please do that.") is True
+    assert cg._resolve("No, don't do that.") in (False, None)
+    assert cg._resolve("Sure, why not.") is True
+
+
+def test_apostrophe_phrase_still_matches():
+    # Regression check: punctuation stripping must not eat the apostrophe in
+    # "don't" itself, or the literal pattern would never match its own
+    # normalized form.
+    assert cg._resolve("Don't do it.") is None or cg._resolve("Don't do it.") is False
+    assert cg._resolve("I don't want that.") is False
+
+
+def test_unrelated_speech_is_ambiguous_not_forced():
+    # Ambient noise / hallucinated filler must never resolve anything --
+    # this is the safety property the whole exact/whole-word design exists
+    # to preserve even after loosening it to accept natural phrasing.
+    assert cg._resolve("Thank you.") is None
+    assert cg._resolve("What's the weather like?") is None
+
+
+def test_ambiguous_when_both_present():
+    # Contains "do it" (confirm) and "no"/"don't" (decline) at once -- should
+    # not confidently resolve either way.
+    assert cg._resolve("no, don't do it") is None
+
+
+def test_estimate_speaking_seconds_scales_with_length_and_has_a_floor():
+    short = cg._estimate_speaking_seconds("Yes")
+    long = cg._estimate_speaking_seconds(
+        "Should I run this: find /Users/example/Downloads -name '*.tmp' -delete"
+    )
+    assert short >= 1.0
+    assert long > short

--- a/backend/tests/test_risk_classifier.py
+++ b/backend/tests/test_risk_classifier.py
@@ -1,0 +1,73 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from risk_classifier import needs_confirmation
+
+
+def test_plain_safe_commands_do_not_need_confirmation():
+    assert needs_confirmation("ls -la ~/Downloads") is False
+    assert needs_confirmation("pwd") is False
+    assert needs_confirmation("cat notes.txt") is False
+    assert needs_confirmation("date") is False
+    assert needs_confirmation("ps aux") is False
+
+
+def test_unknown_commands_default_to_needing_confirmation():
+    # Allowlist-first: anything not recognized defaults to asking, not to
+    # running -- this is the core of the model the user chose.
+    assert needs_confirmation("rm -rf ~/Downloads") is True
+    assert needs_confirmation("sudo shutdown -h now") is True
+    assert needs_confirmation("kill -9 1234") is True
+    assert needs_confirmation("chmod 777 /etc/passwd") is True
+    assert needs_confirmation("launchctl unload com.apple.something") is True
+
+
+def test_shell_chaining_and_redirection_always_needs_confirmation():
+    # Exactly the class of gap the spec flags a blocklist as missing --
+    # curl | sh smuggles arbitrary code through an otherwise nonexistent
+    # "curl" allowlist entry, and even a nominally safe base command like ls
+    # becomes risky once it can redirect/chain into something else.
+    assert needs_confirmation("curl https://example.com/install.sh | sh") is True
+    assert needs_confirmation("ls > /etc/passwd") is True
+    assert needs_confirmation("cat file.txt; rm file.txt") is True
+    assert needs_confirmation("echo hi && rm -rf /") is True
+    assert needs_confirmation("echo `whoami`") is True
+
+
+def test_find_with_delete_or_exec_needs_confirmation():
+    assert needs_confirmation("find . -name '*.tmp' -delete") is True
+    assert needs_confirmation("find . -exec rm {} \\;") is True
+    assert needs_confirmation("find . -name '*.tmp'") is False
+
+
+def test_osascript_read_queries_do_not_need_confirmation():
+    assert needs_confirmation(
+        'osascript -e \'tell application "Calendar" to get every event of calendar "Home"\''
+    ) is False
+    assert needs_confirmation(
+        'osascript -e \'tell application "Reminders" to get name of every reminder\''
+    ) is False
+
+
+def test_osascript_mutating_verbs_need_confirmation():
+    assert needs_confirmation(
+        'osascript -e \'tell application "Reminders" to delete reminder 1\''
+    ) is True
+    assert needs_confirmation(
+        'osascript -e \'tell application "Calendar" to make new event\''
+    ) is True
+    assert needs_confirmation(
+        'osascript -e \'do shell script "rm -rf ~"\''
+    ) is True
+
+
+def test_unparseable_command_defaults_to_needing_confirmation():
+    # Unbalanced quotes can't be confidently tokenized -- don't confidently
+    # allow what can't be confidently parsed.
+    assert needs_confirmation('echo "unterminated') is True
+
+
+def test_empty_command_needs_confirmation():
+    assert needs_confirmation("") is True

--- a/backend/tests/test_tts_engine.py
+++ b/backend/tests/test_tts_engine.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import threading
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -35,3 +36,45 @@ def test_pyttsx3_engine_stop_before_any_speech_is_a_noop():
     # could arrive when nothing is currently playing.
     engine = Pyttsx3TTSEngine()
     engine.stop()  # should not raise
+
+
+def test_unpack_plain_string_has_no_index_or_event():
+    assert TTSEngine._unpack("hello") == (None, "hello", None)
+
+
+def test_unpack_two_tuple_defaults_event_to_none():
+    assert TTSEngine._unpack((3, "hello")) == (3, "hello", None)
+
+
+def test_unpack_three_tuple_passes_event_through():
+    event = threading.Event()
+    assert TTSEngine._unpack((3, "hello", event)) == (3, "hello", event)
+
+
+def test_pyttsx3_done_event_set_when_chunk_skipped_for_empty_text():
+    # An empty chunk is skipped via `continue` before ever touching the real
+    # engine — the done_event must still fire, or a caller waiting on it
+    # (confirmation_gate) would hang forever.
+    engine = Pyttsx3TTSEngine()
+    done_event = threading.Event()
+    engine.speak_stream(iter([(0, "   ", done_event)]))
+    assert done_event.is_set()
+
+
+def test_pyttsx3_done_event_set_when_interrupted_mid_stream():
+    # speak_stream() clears _interrupted at the top of every call (a fresh
+    # call always starts unblocked), so to exercise the early-return path
+    # without ever touching the real pyttsx3 engine, set it partway through
+    # iteration instead of before the call. The done_event for the chunk that
+    # gets skipped this way must still fire, or a waiter would hang forever.
+    engine = Pyttsx3TTSEngine()
+    done_event = threading.Event()
+
+    def items():
+        yield (0, "   ", None)  # empty text, skipped via `continue`
+        engine._interrupted.set()
+        yield (1, "hello", done_event)
+
+    result = engine.speak_stream(items())
+    assert result is False
+    assert done_event.is_set()

--- a/backend/tts_engine.py
+++ b/backend/tts_engine.py
@@ -24,12 +24,19 @@ class TTSEngine:
     True if playback completed all chunks, False if stop() interrupted it
     (checked both between chunks and mid-chunk).
 
-    Each item in text_chunks is either a plain string (no sentence-index
-    tracking needed, e.g. speak_reply's fixed one-shot replies) or an
-    (index, text) tuple — when an index is given, a speech_started broadcast
-    fires right as that chunk starts playing, so the frontend can highlight
-    exactly the sentence currently being spoken rather than guessing from
-    when it was generated/displayed (which runs well ahead of playback).
+    Each item in text_chunks is a plain string (no sentence-index tracking
+    needed, e.g. speak_reply's fixed one-shot replies), an (index, text)
+    tuple, or an (index, text, done_event) tuple. When an index is given, a
+    speech_started broadcast fires right as that chunk starts playing, so the
+    frontend can highlight exactly the sentence currently being spoken rather
+    than guessing from when it was generated/displayed (which runs well ahead
+    of playback). When a done_event (threading.Event) is given, it's set once
+    that specific chunk has actually finished playing (or been skipped/
+    interrupted) — callers that need to know playback genuinely completed,
+    rather than just that it was handed to the TTS consumer, wait on this
+    instead of guessing from word count (see confirmation_gate.py, which
+    needs this so a fast "yes" can't resolve before the user has actually
+    heard the command being read back).
     """
 
     def speak_stream(self, text_chunks) -> bool:
@@ -41,8 +48,11 @@ class TTSEngine:
     @staticmethod
     def _unpack(item):
         if isinstance(item, tuple):
-            return item
-        return None, item
+            if len(item) == 3:
+                return item
+            index, text = item
+            return index, text, None
+        return None, item, None
 
 
 class KokoroTTSEngine(TTSEngine):
@@ -58,18 +68,26 @@ class KokoroTTSEngine(TTSEngine):
     def speak_stream(self, text_chunks) -> bool:
         self._interrupted.clear()
         for item in text_chunks:
-            index, text = self._unpack(item)
-            if self._interrupted.is_set():
-                return False
-            if not text.strip():
-                continue
-            if index is not None:
-                ws_server.broadcast(protocol.speech_started_message(index))
-            for result in self._pipeline(text, voice=self.VOICE):
+            index, text, done_event = self._unpack(item)
+            try:
                 if self._interrupted.is_set():
                     return False
-                if not self._play(result.audio.numpy()):
-                    return False
+                if not text.strip():
+                    continue
+                if index is not None:
+                    ws_server.broadcast(protocol.speech_started_message(index))
+                for result in self._pipeline(text, voice=self.VOICE):
+                    if self._interrupted.is_set():
+                        return False
+                    if not self._play(result.audio.numpy()):
+                        return False
+            finally:
+                # Always signal, even on an early return above (interrupted)
+                # or a skipped empty chunk — a waiter blocked on this event
+                # must never hang just because this chunk didn't actually
+                # play.
+                if done_event is not None:
+                    done_event.set()
         return True
 
     def _play(self, audio: np.ndarray) -> bool:
@@ -132,29 +150,34 @@ class Pyttsx3TTSEngine(TTSEngine):
 
         self._interrupted.clear()
         for item in text_chunks:
-            index, text = self._unpack(item)
-            if self._interrupted.is_set():
-                return False
-            if not text.strip():
-                continue
-            if index is not None:
-                ws_server.broadcast(protocol.speech_started_message(index))
+            index, text, done_event = self._unpack(item)
+            try:
+                if self._interrupted.is_set():
+                    return False
+                if not text.strip():
+                    continue
+                if index is not None:
+                    ws_server.broadcast(protocol.speech_started_message(index))
 
-            # A fresh engine per utterance avoids a known pyttsx3/macOS issue
-            # where the NSSpeechSynthesizer run loop silently stops producing
-            # audio after repeated say()/runAndWait() cycles on one
-            # long-lived engine instance (hit and fixed earlier this project).
-            engine = pyttsx3.init()
-            self._current_engine = engine
-            done = threading.Event()
-            engine.connect("finished-utterance", lambda name, completed: done.set())
-            engine.say(text)
-            engine.runAndWait()
-            done.wait()
-            self._current_engine = None
+                # A fresh engine per utterance avoids a known pyttsx3/macOS
+                # issue where the NSSpeechSynthesizer run loop silently stops
+                # producing audio after repeated say()/runAndWait() cycles on
+                # one long-lived engine instance (hit and fixed earlier this
+                # project).
+                engine = pyttsx3.init()
+                self._current_engine = engine
+                done = threading.Event()
+                engine.connect("finished-utterance", lambda name, completed: done.set())
+                engine.say(text)
+                engine.runAndWait()
+                done.wait()
+                self._current_engine = None
 
-            if self._interrupted.is_set():
-                return False
+                if self._interrupted.is_set():
+                    return False
+            finally:
+                if done_event is not None:
+                    done_event.set()
         return True
 
     def stop(self) -> None:

--- a/docs/E2E_TEST_SCRIPT.md
+++ b/docs/E2E_TEST_SCRIPT.md
@@ -1,0 +1,132 @@
+# Spark End-to-End Test Script
+
+Manual test pass covering everything shipped through Phase 4 (protocol v2,
+SQLite persistence, Kokoro streaming TTS + tap-to-interrupt, orb UI, agentic
+confirmation gates). Run in order — later sections assume the app is already
+up and a session exists.
+
+## Setup
+
+```bash
+cd /Users/kamisettyvivek/Documents/Spark/Spark-Voice-Assistant
+pkill -9 -f "Electron" 2>/dev/null; pkill -9 -f "spark_whisper_mic.py" 2>/dev/null
+npm run start
+```
+
+`main.js` auto-spawns the Python backend (`whisper-env/bin/python spark_whisper_mic.py`)
+— you don't need to launch it separately. Watch the terminal for
+`[Frontend]`/`[Spark]`/`[Claude]` log lines throughout; most assertions below
+are "does the log line + UI agree."
+
+Have a **Downloads folder with at least one file** and **Calendar/Reminders
+with at least one item** for the tool-chaining and osascript tests below.
+
+---
+
+## 1. Launch & lifecycle
+
+| # | Action | Expected |
+|---|---|---|
+| 1.1 | Cold launch | Orb window appears, compact size, state settles to idle (no crash in terminal log) |
+| 1.2 | Quit the app (Cmd+Q or window close) | Terminal log shows the backend process actually exit — no orphaned `spark_whisper_mic.py` left behind. Confirm with `pgrep -fl spark_whisper_mic` after quitting: should be empty |
+
+## 2. Basic voice loop
+
+| # | Action | Expected |
+|---|---|---|
+| 2.1 | Say "What's today's date?" | Orb goes listening (green, mic-RMS-reactive) → thinking (blue, swirl) → speaking (yellow, TTS-RMS-reactive). Panel unfolds showing your transcript (sans-serif) and Spark's reply (serif) |
+| 2.2 | Say something long enough to require Whisper to catch a full sentence (e.g. "Can you tell me a fun fact about space") | First audible word arrives quickly (~1.5s target from Phase 2) — reply isn't fully generated before speech starts |
+| 2.3 | Ask a follow-up referring to the previous answer ("say that again slower") | Claude's reply shows it has the prior turn in context |
+
+## 3. Orb + panel UI
+
+| # | Action | Expected |
+|---|---|---|
+| 3.1 | Watch orb during idle | Slow breathing pulse, no color change |
+| 3.2 | Watch orb while actually speaking into the mic at varying volume | Displacement/amplitude visibly tracks your volume in real time, not just on/off |
+| 3.3 | Watch orb while Spark is speaking | Pulse tracks Spark's own TTS output amplitude |
+| 3.4 | Ask a question, then stay silent | Panel auto-collapses after ~8s idle |
+| 3.5 | Ask something that returns a list/table-shaped answer (e.g. "what files are in my Downloads folder") | Reply headline is short spoken-friendly text; `---DETAIL---` section renders as real markdown (table/list) in the panel, not read aloud verbatim |
+| 3.6 | Click the **Copy** button after a reply | Spark's last reply is on the clipboard |
+| 3.7 | Ask something that triggers a tool call | A muted tool-activity line appears while the tool runs ("Running: ...", "Searching for ...") and disappears when done |
+| 3.8 | Type into the `#text-input` field instead of speaking, press Enter | Same rendering path as voice — appears in transcript, gets a reply |
+| 3.9 | Tap the stop button (`#stop-button`) while Spark is mid-sentence | TTS stops immediately (tap-to-interrupt); note voice barge-in (talking over Spark without tapping) is explicitly out of scope per Phase 2 — don't test that as a bug |
+| 3.10 | Resize / check vibrancy | Window shows real macOS vibrancy (blurred desktop visible behind the panel), rounded corners |
+
+## 4. Session persistence (Phase 1)
+
+| # | Action | Expected |
+|---|---|---|
+| 4.1 | Have a short exchange, e.g. tell Spark "my favorite color is teal" | Normal reply |
+| 4.2 | Quit Spark fully, relaunch | New session starts |
+| 4.3 | Ask "what's my favorite color?" or "what were we just talking about?" | Answers correctly from restored history (loaded from `~/.spark/spark.db`, last 20 messages) |
+| 4.4 (optional) | Inspect DB directly: `sqlite3 ~/.spark/spark.db "select role,content from messages order by id desc limit 5;"` | Rows match what you just said/heard |
+
+## 5. Confirmation gates (Phase 4) — the main new surface
+
+Safe commands (from `risk_classifier.SAFE_COMMANDS`: `ls, pwd, cat, echo, date,
+whoami, uname, hostname, ps, df, du, top, uptime, sw_vers, sysctl, find, grep,
+head, tail, wc, file, stat, which, type, env, printenv, id, groups, ping`)
+auto-run with **no** confirmation. Everything else — including any of those
+same commands combined with `| ; & \` $ < >` — requires confirmation.
+
+| # | Action | Expected |
+|---|---|---|
+| 5.1 | "What's the current date?" (→ `date`) | Runs instantly, no confirmation prompt, no chip |
+| 5.2 | "Ping google.com once" (→ `ping`, safe base command) | Runs instantly, no confirmation |
+| 5.3 | Ask for something that maps to an unlisted command, e.g. "what's my current battery percentage" (likely `pmset` or similar, not in the allowlist) | Spark speaks + panel shows a `confirmation_request` chip ("Should I run this: ...") styled high-risk/red-tinted. State goes to `awaiting_confirmation` (distinct orb color) |
+| 5.4 | Resolve 5.3 by **clicking the "Yes" chip** | Command runs, result comes back, chip disappears (`confirmation_resolved`) |
+| 5.5 | Repeat 5.3, this time resolve by **saying "Yes" (or "go ahead" / "sure" / "okay, go ahead")** out loud | Voice resolves it exactly like the chip — confirm mic is NOT near-silent during this window (Phase 4's mute-deadlock fix); a real spoken yes should transcribe correctly |
+| 5.6 | Repeat 5.3, resolve by **saying "No"** | Command is NOT executed; Spark's tool result should reflect "not run — user did not confirm" |
+| 5.7 | Repeat 5.3, then **say nothing for 30+ seconds** | Times out, auto-denies (same as declining), no command runs |
+| 5.8 | Try a command that chains/redirects even though the base looks safe, e.g. "list my downloads folder and save the output to a file called out.txt" (→ `ls ... > out.txt`) or "run ls and then echo done" (`;`/`&&`) | Requires confirmation even though `ls`/`echo` alone are on the allowlist — this is the "smuggled risk via shell syntax" case from `risk_classifier.RISKY_SHELL_SYNTAX` |
+| 5.9 | Ask Spark to read today's Calendar events (→ `osascript`, read-only) | Auto-runs without confirmation (narrower mutating-verb check for osascript, not a blanket requirement) |
+| 5.10 | Ask Spark to **create** a Reminder or Calendar event (→ `osascript` with `make`/`set`/`save`) | Requires confirmation — mutating AppleScript verb detected |
+| 5.11 | Say "clear history" | Confirmation flow triggers (same general gate, not the old hardcoded one) before anything is wiped; decline it once to confirm nothing is deleted, then confirm it and verify history is actually gone (repeat test 4.3's question afterward — should no longer know the fact) |
+| 5.12 | While a confirmation is pending, say something unrelated, e.g. "thank you" or random ambient chatter | Ignored — logged as unrelated input, confirmation stays pending (not treated as an implicit decline). Verify by then actually answering "yes" afterward and having it still resolve correctly |
+| 5.13 | Ask for something clearly destructive, e.g. "delete everything in my Downloads folder" | Triggers confirmation; decline it (say "no") and verify via `ls ~/Downloads` that nothing was actually deleted |
+
+## 6. Multi-step tool chaining
+
+| # | Action | Expected |
+|---|---|---|
+| 6.1 | "Find my resume and copy it to the Desktop" (adjust filename to something real on your machine) | Multiple tool calls chain (search_files → execute_shell_command for the copy, which will itself need confirmation per §5) without you having to prompt each step separately |
+| 6.2 | Ask something that would require many back-and-forth tool attempts to fail (hard to force deliberately — optional) | After `MAX_TOOL_ITERATIONS = 8`, Spark gracefully says it needed more steps than expected rather than looping forever |
+
+## 7. Screenshot / visual Q&A (if Screen Recording permission granted to the Electron/terminal process)
+
+| # | Action | Expected |
+|---|---|---|
+| 7.1 | Have something on screen, ask "what's on my screen right now?" | Screenshot captured, Claude describes it accurately |
+| 7.2 | If permission was never granted | Spark tells you to enable Screen Recording in System Settings rather than claiming it can never see the screen |
+
+## 8. Regression sweep (quick)
+
+- [ ] `open_application`: "open Safari" / "open Spotify" — runs with no confirmation gate (not shell-classified), opens correctly, or reports a clear failure if the app name doesn't resolve.
+- [ ] Markdown/code rendering: ask for a short code snippet, verify syntax highlighting in the panel.
+- [ ] `search_files`: "find all PDFs in my Documents folder" — returns real matches, capped list.
+- [ ] Numbered-list replies render correctly (not corrupted at "1." — the `sentence_splitter.py` fix).
+
+---
+
+## Automated backend check (run first, cheap)
+
+```bash
+cd backend && ./whisper-env/bin/python -m pytest tests/ -q
+```
+
+Should be 42/42 passing before doing any of the manual voice pass above — if
+this fails, fix it before burning time on live testing.
+
+## Cleanup after testing
+
+```bash
+pkill -9 -f "Electron" 2>/dev/null
+pkill -9 -f "spark_whisper_mic.py" 2>/dev/null
+```
+
+Delete any ad-hoc screenshots/log files left in the parent `Spark/` directory
+(never inside the repo) — check with:
+```bash
+ls /Users/kamisettyvivek/Documents/Spark/*.png /tmp/spark_*.log 2>/dev/null
+```


### PR DESCRIPTION
## Summary
- Adds an allowlist-first risk classifier for `execute_shell_command` — only commands confidently recognized as safe/read-only auto-run; anything else (including any shell chaining/redirection like `curl | sh`) requires confirmation.
- Generalizes the confirmation system: any tool call can now gate on a real confirmation (chip click or spoken/typed yes-no), not just the old hardcoded "clear history" flow, which now uses the same general gate.
- Real per-command audit logging to SQLite (actual command + result), replacing the old "used tools: X" summary.
- Fixes a real deadlock found during manual testing: the mic's actual input volume stayed muted for the entire confirmation wait (tied to the prompt being spoken, normally only undone once the whole tool call resolves), so a genuine spoken "yes" came through as a near-silent, unusable clip. New `mic_control.py` module + explicit unmute/mute around the response window fixes this.
- Fixes mic capture truncating short confirmation words ("yes"/"no") to nothing, then over-corrects by trimming back to ~200ms of trailing context (full silence-grace capture alone was pushing Whisper into "Thank you." hallucinations on near-silent padding).
- Confirmation phrase matching now accepts natural phrasing ("Okay, go ahead.") instead of requiring an exact full-string match, and the response-timeout clock now starts after the prompt is actually spoken instead of before.
- Filler-phrase filtering ("Thank you.", etc.) now happens before display broadcast instead of after, so a stray hallucination can't wipe the latest-exchange panel.

## Test plan
- [x] 42/42 backend unit tests pass (`pytest tests/`)
- [x] Live-verified with real speech: safe commands (`date`) run instantly with no prompt
- [x] Live-verified: unlisted-but-harmless commands require confirmation, resolved via chip click
- [x] Live-verified: resolved via spoken/typed voice, including while the executing thread is blocked waiting
- [x] Live-verified: declining prevents execution entirely
- [x] Live-verified: 30s timeout auto-denies
- [x] Live-verified end-to-end: asked to find and kill the app's own Electron process — correctly required confirmation, Claude proactively re-confirmed given the severity, executed exactly what was confirmed (killed a recoverable Electron sub-process, not the unrecoverable main one)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>