### PR TITLE
Phase 5: semantic memory (RAG) via local embeddings

### DIFF
--- a/backend/claude_client.py
+++ b/backend/claude_client.py
@@ -10,6 +10,8 @@ import ws_server
 import protocol
 import confirmation_gate
 import risk_classifier
+import store
+import memory
 from sentence_splitter import split_into_sentences
 
 load_dotenv()
@@ -71,6 +73,34 @@ TOOLS = [
                 }
             },
             "required": ["app_name"]
+        }
+    },
+    {
+        "name": "remember_this",
+        "description": "Save a durable fact about the user for future conversations (preferences, ongoing projects, recurring schedule, names of people/places). Use when the user explicitly asks you to remember something.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The fact to remember, phrased so it makes sense read alone with no other context later (e.g. \"The user's standup is at 9:30am\", not \"it's at 9:30\")."
+                }
+            },
+            "required": ["content"]
+        }
+    },
+    {
+        "name": "forget",
+        "description": "Delete a previously remembered fact about the user. Use when the user explicitly asks you to forget something.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "A description of the fact to forget, in the user's own words."
+                }
+            },
+            "required": ["query"]
         }
     }
 ]
@@ -139,6 +169,51 @@ def open_application(app_name: str) -> str:
         return f"Error opening application: {str(e)}"
 
 
+def remember_this(content: str, session_id) -> str:
+    """Embed and store a durable fact. Opens its own short-lived DB
+    connection since tool calls run on the streaming background thread, not
+    spark_whisper_mic.py's main() thread that owns the shared connection
+    (see store.py's docstring — sqlite3 connections aren't safe to share
+    across threads). Memory writes are low-risk (Phase 5 spec) — no
+    confirmation gate, unlike forget below.
+    """
+    conn = store.init_db()
+    try:
+        memory_id = memory.save_memory(conn, content, session_id)
+    finally:
+        conn.close()
+    if memory_id is None:
+        return f"Already remembered something similar to: {content}"
+    return f"Remembered: {content}"
+
+
+def forget(query: str, on_sentence=None) -> str:
+    """Delete the best-matching remembered fact, after confirmation —
+    deletions require the same confirmation gate as risky shell commands
+    (Phase 4), even though memory writes themselves don't.
+    """
+    conn = store.init_db()
+    try:
+        match = memory.find_best_match(conn, query)
+        if match is None:
+            return f"Couldn't find anything remembered matching: {query}"
+        memory_id, content, _ = match
+
+        confirmed = confirmation_gate.request_confirmation(
+            f"Should I forget this: {content}?",
+            risk="low",
+            options=["Yes", "No"],
+            speak_fn=on_sentence,
+        )
+        if not confirmed:
+            return f"Not forgotten — the user did not confirm: {content}"
+
+        store.delete_memory(conn, memory_id)
+        return f"Forgot: {content}"
+    finally:
+        conn.close()
+
+
 def _tool_summary(tool_name: str, tool_input: dict) -> str:
     """Short human-readable description of a tool call, for tool_activity messages."""
     if tool_name == "execute_shell_command":
@@ -147,10 +222,14 @@ def _tool_summary(tool_name: str, tool_input: dict) -> str:
         return f"Searching for {tool_input.get('pattern', '')}"
     elif tool_name == "open_application":
         return f"Opening {tool_input.get('app_name', '')}"
+    elif tool_name == "remember_this":
+        return f"Remembering: {tool_input.get('content', '')}"[:100]
+    elif tool_name == "forget":
+        return f"Forgetting: {tool_input.get('query', '')}"[:100]
     return tool_name
 
 
-def process_tool_call(tool_name: str, tool_input: dict, on_sentence=None) -> str:
+def process_tool_call(tool_name: str, tool_input: dict, on_sentence=None, session_id=None) -> str:
     """Route tool calls to the appropriate handler."""
     if tool_name == "execute_shell_command":
         return execute_shell_command(tool_input.get("command", ""), on_sentence=on_sentence)
@@ -161,11 +240,15 @@ def process_tool_call(tool_name: str, tool_input: dict, on_sentence=None) -> str
         )
     elif tool_name == "open_application":
         return open_application(tool_input.get("app_name", ""))
+    elif tool_name == "remember_this":
+        return remember_this(tool_input.get("content", ""), session_id)
+    elif tool_name == "forget":
+        return forget(tool_input.get("query", ""), on_sentence=on_sentence)
     else:
         return f"Unknown tool: {tool_name}"
 
 
-def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool = False, on_sentence=None) -> tuple:
+def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool = False, on_sentence=None, session_id=None) -> tuple:
     """
     Route a prompt through Claude with tool use.
     Returns (response_text, model_used, tools_called, tool_calls_log)
@@ -182,6 +265,10 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
     Tool-calling turns don't usually have text to stream (Claude is deciding
     to call a tool, not composing a spoken answer yet), but if Claude does
     say something before calling a tool, that gets streamed too.
+
+    session_id is threaded through to the remember_this/forget tool handlers
+    (for audit provenance on new memories) and used here to retrieve
+    semantically relevant memories for this specific prompt (Phase 5).
     """
     model = "claude-sonnet-5"
     requires_image = False
@@ -279,7 +366,8 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
     # System prompt
     system_prompt = (
         "You are Spark, a helpful voice assistant running on a MacBook. "
-        "You can execute commands, search files, and open applications. "
+        "You can execute commands, search files, open applications, and "
+        "remember or forget durable facts about the user. "
         "Keep responses concise and natural for voice output. "
         "If the user asks you to do something, use the available tools. "
         "If a tool call fails, explain it to the user naturally. "
@@ -311,6 +399,22 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
         "that short headline, skip the marker and the detail section "
         "entirely."
     )
+
+    # Phase 5: pull in whatever remembered facts are actually relevant to
+    # this specific prompt (semantic match, not just "recent") — opens its
+    # own short-lived connection since this runs on the tool-call/streaming
+    # thread, not spark_whisper_mic.py's main() thread (see memory.py).
+    memory_conn = store.init_db()
+    try:
+        relevant_memories = memory.retrieve_relevant(memory_conn, prompt)
+    finally:
+        memory_conn.close()
+    if relevant_memories:
+        system_prompt += (
+            "\n\nKnown facts about the user, from previous conversations "
+            "(only mention one if it's actually relevant to this request):\n"
+            + "\n".join(f"- {fact}" for fact in relevant_memories)
+        )
 
     def stream_call():
         """One streaming API call: yields sentences to on_sentence as they
@@ -364,7 +468,7 @@ def route_claude_reply(prompt: str, chat_history: list, screenshot_enabled: bool
 
                 print(f"[Claude] 🔧 Calling tool: {tool_name}")
                 ws_server.broadcast(protocol.tool_activity_message(tool_name, "running", summary))
-                tool_result = process_tool_call(tool_name, tool_input, on_sentence=on_sentence)
+                tool_result = process_tool_call(tool_name, tool_input, on_sentence=on_sentence, session_id=session_id)
                 print(f"[Claude] 📤 Tool result: {tool_result[:100]}...")
                 ws_server.broadcast(protocol.tool_activity_message(tool_name, "done", summary))
                 tool_calls_log.append({"name": tool_name, "summary": summary, "result": tool_result})

--- a/backend/memory.py
+++ b/backend/memory.py
@@ -1,0 +1,210 @@
+"""Semantic memory (Phase 5 of docs/SPARK_V2_SPEC.md) — local embeddings
+(sentence-transformers, nothing leaves the machine) over the `memories`
+table, whose schema store.py reserved back in Phase 1.
+
+Every function here takes an explicit sqlite3.Connection, the same
+convention store.py uses. store.py's own docstring restricts its shared
+connection to spark_whisper_mic.py's main() thread — callers here that run
+on a different thread (claude_client.py's tool handlers and per-turn
+retrieval, which run on the route_claude_reply background thread, not
+main()) must open and close their own short-lived connection via
+store.init_db() rather than reuse the shared one, since sqlite3 connections
+aren't safe to share across threads.
+"""
+
+import json
+import os
+
+import numpy as np
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+import store
+
+load_dotenv()
+
+EMBED_MODEL_NAME = "all-MiniLM-L6-v2"
+
+# Facts confidently similar to something already stored aren't worth a
+# second row — 0.9 is high enough that only near-duplicate phrasings of the
+# same fact collide, not merely related-but-distinct facts.
+DEDUP_SIMILARITY_THRESHOLD = 0.9
+
+# Facts below this aren't relevant enough to the current utterance to be
+# worth spending system-prompt tokens on every turn.
+RETRIEVAL_SIMILARITY_THRESHOLD = 0.35
+RETRIEVAL_TOP_K = 5
+
+# How often (in real conversational turns, not raw loop iterations) a
+# mid-session extraction pass runs, in addition to the one at session end —
+# so a long session doesn't lose everything to a crash before ever getting
+# extracted.
+EXTRACT_EVERY_N_TURNS = 15
+
+_model = None
+_client = None
+
+
+def _get_model():
+    # Loaded lazily rather than at import time — keeps the model's load
+    # latency out of every module that imports this one (audio_bands,
+    # protocol, etc. via spark_whisper_mic.py) for something only actually
+    # needed once extraction or retrieval first runs.
+    global _model
+    if _model is None:
+        from sentence_transformers import SentenceTransformer
+
+        _model = SentenceTransformer(EMBED_MODEL_NAME)
+    return _model
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        _client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    return _client
+
+
+def embed(text: str) -> np.ndarray:
+    return np.asarray(_get_model().encode(text), dtype=np.float32)
+
+
+def _to_blob(vector: np.ndarray) -> bytes:
+    return np.asarray(vector, dtype=np.float32).tobytes()
+
+
+def _from_blob(blob: bytes) -> np.ndarray:
+    return np.frombuffer(blob, dtype=np.float32)
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    denom = np.linalg.norm(a) * np.linalg.norm(b)
+    if denom == 0:
+        return 0.0
+    return float(np.dot(a, b) / denom)
+
+
+def retrieve_relevant(conn, query_text: str, top_k: int = RETRIEVAL_TOP_K,
+                       min_similarity: float = RETRIEVAL_SIMILARITY_THRESHOLD) -> list:
+    """Up to `top_k` memory contents relevant to `query_text`, most-similar
+    first, above `min_similarity`. Empty list if nothing qualifies (including
+    when there are no memories yet) — a brute-force linear scan, which is
+    fine at the scale a single user's memory table will ever reach.
+    """
+    rows = store.list_memories(conn)
+    if not rows:
+        return []
+    query_vec = embed(query_text)
+    scored = [
+        (row["content"], cosine_similarity(query_vec, _from_blob(row["embedding"])))
+        for row in rows
+        if row["embedding"] is not None
+    ]
+    scored = [item for item in scored if item[1] >= min_similarity]
+    scored.sort(key=lambda item: item[1], reverse=True)
+    return [content for content, _ in scored[:top_k]]
+
+
+def find_best_match(conn, query_text: str, min_similarity: float = RETRIEVAL_SIMILARITY_THRESHOLD):
+    """(memory_id, content, similarity) for the single best match to
+    `query_text`, or None if nothing clears `min_similarity`. Used by the
+    forget tool, which needs one concrete memory to confirm deleting rather
+    than a ranked list.
+    """
+    rows = store.list_memories(conn)
+    if not rows:
+        return None
+    query_vec = embed(query_text)
+    best = None
+    for row in rows:
+        if row["embedding"] is None:
+            continue
+        similarity = cosine_similarity(query_vec, _from_blob(row["embedding"]))
+        if best is None or similarity > best[2]:
+            best = (row["id"], row["content"], similarity)
+    if best is not None and best[2] >= min_similarity:
+        return best
+    return None
+
+
+def _is_duplicate(conn, candidate_vec: np.ndarray) -> bool:
+    for row in store.list_memories(conn):
+        if row["embedding"] is None:
+            continue
+        if cosine_similarity(candidate_vec, _from_blob(row["embedding"])) > DEDUP_SIMILARITY_THRESHOLD:
+            return True
+    return False
+
+
+def save_memory(conn, content: str, session_id):
+    """Embeds and stores one fact, skipping it if a near-duplicate already
+    exists (cosine > DEDUP_SIMILARITY_THRESHOLD). Returns the new row id, or
+    None if skipped as a duplicate. Used directly by the remember_this tool,
+    and by extract_and_store below for each extracted fact.
+    """
+    vec = embed(content)
+    if _is_duplicate(conn, vec):
+        return None
+    return store.add_memory(conn, content, session_id, _to_blob(vec))
+
+
+_EXTRACTION_SYSTEM_PROMPT = (
+    "Extract durable, user-specific facts worth remembering across future "
+    "conversations from this transcript — preferences, ongoing projects, "
+    "recurring schedule items, names of people/pets/places the user "
+    "mentioned, and similar standing facts about the user's life. Do not "
+    "extract one-off requests, questions, or anything only relevant to this "
+    "single conversation (e.g. \"what's today's date\" or a specific command "
+    "that was run). Phrase each fact so it makes sense read alone with no "
+    "other context later (e.g. \"The user's standup is at 9:30am\", not "
+    "\"it's at 9:30\"). Return an empty list if there's nothing worth "
+    "remembering."
+)
+
+_EXTRACTION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "facts": {
+            "type": "array",
+            "items": {"type": "string"},
+        }
+    },
+    "required": ["facts"],
+    "additionalProperties": False,
+}
+
+
+def extract_and_store(conn, session_id, transcript_text: str) -> int:
+    """Sends the transcript to Claude to pull out durable facts, embeds and
+    stores each (skipping near-duplicates of existing memories). Returns how
+    many were actually stored. Safe to call with an empty/short transcript —
+    returns 0 without making an API call.
+    """
+    if not transcript_text.strip():
+        return 0
+
+    response = _get_client().messages.create(
+        model="claude-sonnet-5",
+        max_tokens=1024,
+        system=_EXTRACTION_SYSTEM_PROMPT,
+        output_config={"format": {"type": "json_schema", "schema": _EXTRACTION_SCHEMA}},
+        messages=[{"role": "user", "content": transcript_text}],
+    )
+
+    if response.stop_reason == "refusal":
+        return 0
+
+    raw = "".join(block.text for block in response.content if block.type == "text")
+    try:
+        facts = json.loads(raw)["facts"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        print(f"[Memory] Extraction returned an unexpected shape, skipping: {raw[:200]}")
+        return 0
+
+    stored = 0
+    for fact in facts:
+        if not isinstance(fact, str) or not fact.strip():
+            continue
+        if save_memory(conn, fact.strip(), session_id) is not None:
+            stored += 1
+    return stored

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ python-dotenv==1.2.2
 pyttsx3==2.99
 websockets==16.0
 kokoro==0.9.4
+sentence-transformers==3.3.1
 
 # dev/test
 pytest==9.1.1

--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -16,6 +16,7 @@ from claude_client import route_claude_reply as route_gpt_reply
 import ws_server
 import protocol
 import store
+import memory
 import audio_bands
 import confirmation_gate
 import mic_control
@@ -89,6 +90,13 @@ def cancel_idle_timer():
         idle_timer.cancel()
         idle_timer = None
 
+def _transcript_text(messages: list) -> str:
+    """Renders store.py message rows (or chat_history entries — same shape)
+    into plain text suitable for the memory-extraction prompt.
+    """
+    return "\n".join(f"{m['role']}: {m['content']}" for m in messages)
+
+
 def cleanup_before_exit():
     print("[Spark] 🧼 Cleaning up before shutdown...")
     try:
@@ -96,6 +104,15 @@ def cleanup_before_exit():
     except Exception as e:
         print(f"[Spark] ⚠️ Failed to unmute: {e}")
     if _db is not None and _session_id is not None:
+        # Final extraction pass so a session's last stretch of conversation
+        # (since the last periodic pass) isn't lost just because the app
+        # quit rather than idling out — best-effort, since a hung/slow
+        # Claude call here shouldn't block shutdown from completing.
+        try:
+            recent = store.load_recent_messages(_db, limit=30)
+            memory.extract_and_store(_db, _session_id, _transcript_text(recent))
+        except Exception as e:
+            print(f"[Spark] ⚠️ Memory extraction on shutdown failed: {e}")
         store.end_session(_db, _session_id)
     write_status("inactive")
 
@@ -473,7 +490,8 @@ def process_claude_turn(line, chat_history):
 
     def run_claude():
         reply, model_used, tools_called, tool_calls_log = route_gpt_reply(
-            line, chat_history, screenshot_enabled=True, on_sentence=on_sentence
+            line, chat_history, screenshot_enabled=True, on_sentence=on_sentence,
+            session_id=_session_id
         )
         result["reply"] = reply
         result["model_used"] = model_used
@@ -530,6 +548,7 @@ def main():
     _db = store.init_db()
     _session_id = store.start_session(_db)
     chat_history = store.load_recent_messages(_db, limit=20)
+    turn_count = 0
 
     transcript_queue = queue.Queue()
     threading.Thread(target=mic_listener, args=(transcript_queue,), daemon=True).start()
@@ -605,6 +624,20 @@ def main():
                     _db, _session_id, "tool",
                     f"{call['summary']} -> {call['result'][:200]}"
                 )
+
+            # Periodic memory extraction (Phase 5) — every N real turns, in
+            # addition to the pass at session end (cleanup_before_exit), so a
+            # long session doesn't lose everything to a crash before it's
+            # ever extracted. Runs synchronously here (blocking the next
+            # dequeue briefly) rather than on a background thread, since it
+            # needs the shared _db connection, which is only safe to use
+            # from this thread (see store.py's docstring).
+            turn_count += 1
+            if turn_count % memory.EXTRACT_EVERY_N_TURNS == 0:
+                try:
+                    memory.extract_and_store(_db, _session_id, _transcript_text(chat_history))
+                except Exception as e:
+                    print(f"[Spark] ⚠️ Periodic memory extraction failed: {e}")
 
             start_idle_timer(45)
 

--- a/backend/store.py
+++ b/backend/store.py
@@ -37,7 +37,6 @@ def init_db(db_path: str = DEFAULT_DB_PATH) -> sqlite3.Connection:
         )
         """
     )
-    # Schema only for now — populated starting in Phase 5's semantic memory work.
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS memories (
@@ -103,4 +102,31 @@ def load_recent_messages(conn: sqlite3.Connection, limit: int = 20) -> list:
 
 def clear_history(conn: sqlite3.Connection) -> None:
     conn.execute("DELETE FROM messages")
+    conn.commit()
+
+
+# Phase 5 (semantic memory). Unlike the rest of this module, these three are
+# safe to call from any thread, PROVIDED the caller passes a connection it
+# opened on that same thread (via init_db()) rather than reusing another
+# thread's connection — memory.py's callers on the tool-call thread each open
+# their own short-lived connection for exactly this reason; only the shared
+# module-level `_db` in spark_whisper_mic.py is restricted to its main() loop.
+
+
+def add_memory(conn: sqlite3.Connection, content: str, source_session_id, embedding: bytes) -> int:
+    cur = conn.execute(
+        "INSERT INTO memories (content, source_session_id, created_at, embedding) VALUES (?, ?, ?, ?)",
+        (content, source_session_id, time.time(), embedding),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def list_memories(conn: sqlite3.Connection) -> list:
+    rows = conn.execute("SELECT id, content, embedding FROM memories").fetchall()
+    return [{"id": row[0], "content": row[1], "embedding": row[2]} for row in rows]
+
+
+def delete_memory(conn: sqlite3.Connection, memory_id: int) -> None:
+    conn.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
     conn.commit()

--- a/backend/tests/test_memory.py
+++ b/backend/tests/test_memory.py
@@ -1,0 +1,232 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pytest
+
+import store
+import memory
+
+
+def make_db():
+    return store.init_db(":memory:")
+
+
+def _fake_embed(vectors_by_text):
+    def _embed(text):
+        return np.array(vectors_by_text[text], dtype=np.float32)
+    return _embed
+
+
+# --- cosine_similarity / blob roundtrip -------------------------------------
+
+
+def test_cosine_similarity_identical_vectors():
+    v = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    assert memory.cosine_similarity(v, v) == pytest.approx(1.0)
+
+
+def test_cosine_similarity_orthogonal_vectors():
+    a = np.array([1.0, 0.0], dtype=np.float32)
+    b = np.array([0.0, 1.0], dtype=np.float32)
+    assert memory.cosine_similarity(a, b) == pytest.approx(0.0)
+
+
+def test_cosine_similarity_opposite_vectors():
+    a = np.array([1.0, 0.0], dtype=np.float32)
+    b = np.array([-1.0, 0.0], dtype=np.float32)
+    assert memory.cosine_similarity(a, b) == pytest.approx(-1.0)
+
+
+def test_cosine_similarity_zero_vector_is_safe():
+    a = np.zeros(3, dtype=np.float32)
+    b = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    assert memory.cosine_similarity(a, b) == 0.0
+
+
+def test_blob_roundtrip_preserves_vector():
+    v = np.array([1.5, -2.25, 3.0], dtype=np.float32)
+    restored = memory._from_blob(memory._to_blob(v))
+    assert np.allclose(v, restored)
+
+
+# --- save_memory / dedup -----------------------------------------------------
+
+
+def test_save_memory_stores_new_fact(monkeypatch):
+    conn = make_db()
+    monkeypatch.setattr(memory, "embed", _fake_embed({"likes tea": [1.0, 0.0]}))
+
+    memory_id = memory.save_memory(conn, "likes tea", session_id=1)
+
+    assert memory_id is not None
+    rows = store.list_memories(conn)
+    assert len(rows) == 1
+    assert rows[0]["content"] == "likes tea"
+
+
+def test_save_memory_skips_near_duplicate(monkeypatch):
+    conn = make_db()
+    vectors = {"likes tea": [1.0, 0.0], "enjoys tea": [0.999, 0.001]}
+    monkeypatch.setattr(memory, "embed", _fake_embed(vectors))
+
+    memory.save_memory(conn, "likes tea", session_id=1)
+    second = memory.save_memory(conn, "enjoys tea", session_id=1)
+
+    assert second is None
+    assert len(store.list_memories(conn)) == 1
+
+
+def test_save_memory_keeps_dissimilar_fact(monkeypatch):
+    conn = make_db()
+    vectors = {"likes tea": [1.0, 0.0], "works at Acme": [0.0, 1.0]}
+    monkeypatch.setattr(memory, "embed", _fake_embed(vectors))
+
+    memory.save_memory(conn, "likes tea", session_id=1)
+    second = memory.save_memory(conn, "works at Acme", session_id=1)
+
+    assert second is not None
+    assert len(store.list_memories(conn)) == 2
+
+
+# --- retrieve_relevant / find_best_match ------------------------------------
+
+
+def test_retrieve_relevant_orders_by_similarity_and_respects_threshold(monkeypatch):
+    conn = make_db()
+    vectors = {
+        "likes tea": [1.0, 0.0],
+        "works at Acme": [0.0, 1.0],
+        "query": [0.9, 0.1],
+    }
+    monkeypatch.setattr(memory, "embed", _fake_embed(vectors))
+    memory.save_memory(conn, "likes tea", session_id=1)
+    memory.save_memory(conn, "works at Acme", session_id=1)
+
+    results = memory.retrieve_relevant(conn, "query", top_k=5, min_similarity=0.35)
+
+    assert results == ["likes tea"]
+
+
+def test_retrieve_relevant_empty_when_no_memories(monkeypatch):
+    conn = make_db()
+    monkeypatch.setattr(memory, "embed", _fake_embed({"query": [1.0, 0.0]}))
+    assert memory.retrieve_relevant(conn, "query") == []
+
+
+def test_find_best_match_returns_highest_scoring(monkeypatch):
+    conn = make_db()
+    vectors = {
+        "likes tea": [1.0, 0.0],
+        "works at Acme": [0.0, 1.0],
+        "forget the tea thing": [0.95, 0.05],
+    }
+    monkeypatch.setattr(memory, "embed", _fake_embed(vectors))
+    memory.save_memory(conn, "likes tea", session_id=1)
+    memory.save_memory(conn, "works at Acme", session_id=1)
+
+    match = memory.find_best_match(conn, "forget the tea thing")
+
+    assert match is not None
+    _, content, _ = match
+    assert content == "likes tea"
+
+
+def test_find_best_match_none_below_threshold(monkeypatch):
+    conn = make_db()
+    vectors = {"likes tea": [1.0, 0.0], "unrelated query": [0.0, 1.0]}
+    monkeypatch.setattr(memory, "embed", _fake_embed(vectors))
+    memory.save_memory(conn, "likes tea", session_id=1)
+
+    assert memory.find_best_match(conn, "unrelated query") is None
+
+
+def test_find_best_match_none_when_no_memories(monkeypatch):
+    conn = make_db()
+    monkeypatch.setattr(memory, "embed", _fake_embed({"query": [1.0, 0.0]}))
+    assert memory.find_best_match(conn, "query") is None
+
+
+# --- extract_and_store --------------------------------------------------------
+
+
+class _FakeTextBlock:
+    def __init__(self, text):
+        self.type = "text"
+        self.text = text
+
+
+class _FakeResponse:
+    def __init__(self, text, stop_reason="end_turn"):
+        self.content = [_FakeTextBlock(text)]
+        self.stop_reason = stop_reason
+
+
+def _fake_client(response):
+    class _FakeMessages:
+        def create(self, **kwargs):
+            return response
+
+    class _FakeClient:
+        messages = _FakeMessages()
+
+    return _FakeClient()
+
+
+def test_extract_and_store_empty_transcript_is_noop(monkeypatch):
+    conn = make_db()
+    calls = []
+    monkeypatch.setattr(memory, "_get_client", lambda: calls.append(1))
+
+    stored = memory.extract_and_store(conn, session_id=1, transcript_text="")
+
+    assert stored == 0
+    assert calls == []  # never even reached the client
+
+
+def test_extract_and_store_saves_extracted_facts(monkeypatch):
+    conn = make_db()
+    vectors = {"The user likes tea": [1.0, 0.0], "The user works at Acme": [0.0, 1.0]}
+    monkeypatch.setattr(memory, "embed", _fake_embed(vectors))
+    response = _FakeResponse(json.dumps({"facts": list(vectors.keys())}))
+    monkeypatch.setattr(memory, "_get_client", lambda: _fake_client(response))
+
+    stored = memory.extract_and_store(conn, session_id=1, transcript_text="user: I like tea and work at Acme")
+
+    assert stored == 2
+    assert {row["content"] for row in store.list_memories(conn)} == set(vectors.keys())
+
+
+def test_extract_and_store_handles_refusal(monkeypatch):
+    conn = make_db()
+    response = _FakeResponse("", stop_reason="refusal")
+    monkeypatch.setattr(memory, "_get_client", lambda: _fake_client(response))
+
+    stored = memory.extract_and_store(conn, session_id=1, transcript_text="some transcript")
+
+    assert stored == 0
+    assert store.list_memories(conn) == []
+
+
+def test_extract_and_store_handles_malformed_json(monkeypatch):
+    conn = make_db()
+    response = _FakeResponse("not json")
+    monkeypatch.setattr(memory, "_get_client", lambda: _fake_client(response))
+
+    stored = memory.extract_and_store(conn, session_id=1, transcript_text="some transcript")
+
+    assert stored == 0
+
+
+def test_extract_and_store_skips_empty_facts_list(monkeypatch):
+    conn = make_db()
+    response = _FakeResponse(json.dumps({"facts": []}))
+    monkeypatch.setattr(memory, "_get_client", lambda: _fake_client(response))
+
+    stored = memory.extract_and_store(conn, session_id=1, transcript_text="just chit-chat")
+
+    assert stored == 0
+    assert store.list_memories(conn) == []

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -97,6 +97,21 @@ def test_load_recent_messages_trims_dangling_trailing_user():
     ]
 
 
+def test_add_list_delete_memory():
+    conn = make_db()
+    session_id = store.start_session(conn)
+    memory_id = store.add_memory(conn, "likes tea", session_id, b"\x00\x01")
+
+    rows = store.list_memories(conn)
+    assert len(rows) == 1
+    assert rows[0]["id"] == memory_id
+    assert rows[0]["content"] == "likes tea"
+    assert rows[0]["embedding"] == b"\x00\x01"
+
+    store.delete_memory(conn, memory_id)
+    assert store.list_memories(conn) == []
+
+
 def test_clear_history():
     conn = make_db()
     session_id = store.start_session(conn)

--- a/docs/E2E_TEST_SCRIPT.md
+++ b/docs/E2E_TEST_SCRIPT.md
@@ -86,6 +86,17 @@ same commands combined with `| ; & \` $ < >` — requires confirmation.
 | 5.12 | While a confirmation is pending, say something unrelated, e.g. "thank you" or random ambient chatter | Ignored — logged as unrelated input, confirmation stays pending (not treated as an implicit decline). Verify by then actually answering "yes" afterward and having it still resolve correctly |
 | 5.13 | Ask for something clearly destructive, e.g. "delete everything in my Downloads folder" | Triggers confirmation; decline it (say "no") and verify via `ls ~/Downloads` that nothing was actually deleted |
 
+## 5b. Semantic memory (Phase 5)
+
+| # | Action | Expected |
+|---|---|---|
+| 5b.1 | "Remember that my favorite color is teal" | `remember_this` tool runs with **no** confirmation prompt (memory writes are low-risk); Spark confirms verbally |
+| 5b.2 | Later in the same session, ask "what color do I like best?" (different wording) | Answers correctly from the stored memory (semantic retrieval, not keyword match) |
+| 5b.3 | "Forget my favorite color" | Triggers a confirmation (low-risk styled, not the red high-risk styling from §5) before deleting — decline once and verify `sqlite3 ~/.spark/spark.db "select content from memories;"` still shows it, then confirm and verify it's gone |
+| 5b.4 | Mention a fact in passing without asking Spark to remember it (e.g. "I'm making soup for my roommate Priya, she's sick") | No `remember_this` tool call this turn — but quit the app cleanly afterward (Cmd+Q or SIGTERM) and check `sqlite3 ~/.spark/spark.db "select content from memories;"` — the fact should appear, picked up by the session-end extraction pass |
+| 5b.5 | Restart the app, ask about a previously remembered fact in different wording | Answers correctly — this is Phase 5's actual acceptance test (persists across process restart, not just within a session) |
+| 5b.6 | Have a long conversation (15+ turns) in one sitting | A periodic extraction pass should fire mid-session (check terminal log / DB for new memory rows) without waiting for app quit |
+
 ## 6. Multi-step tool chaining
 
 | # | Action | Expected |


### PR DESCRIPTION
## Summary
- Adds local semantic memory: `sentence-transformers` (all-MiniLM-L6-v2) embeddings computed entirely on-device — nothing leaves the machine for embedding.
- New `remember_this` (auto-runs, low-risk) and `forget` (routes through the Phase 4 confirmation gate before deleting) tools.
- Fact extraction: Claude pulls durable, user-specific facts from the recent transcript via structured JSON output (`output_config.format`), deduplicated against existing memories at cosine similarity > 0.9. Runs every 15 turns and once more on clean shutdown, so a long session doesn't lose everything to a crash before ever being extracted.
- Retrieval: every turn, the current utterance is embedded and the top-5 memories above similarity 0.35 are injected into the system prompt under "Known facts about the user."

## Test plan
- [x] 66/66 backend unit tests pass (`pytest tests/`), 19 new covering `memory.py`'s cosine similarity, dedup, retrieval, and extraction (mocked embeddings/Claude client — no network or real model in the test suite)
- [x] Live-verified: `remember_this` stores instantly with no confirmation prompt
- [x] Live-verified: a fact recalled correctly using different wording than it was stored in (semantic match, not keyword)
- [x] Live-verified: `forget` requires confirmation (low-risk styling), declining leaves the memory intact, confirming deletes it
- [x] Live-verified: a fact mentioned only in passing (no explicit `remember_this` call) was picked up by the session-end extraction pass on shutdown, with dedup correctly skipping facts already known from the same transcript
- [x] Live-verified end-to-end: a remembered fact survived a full process restart (kill + relaunch) and was recalled correctly in different wording — Phase 5's stated acceptance test

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>