### PR TITLE
Phase 6: morning briefing (narrow proactivity)

### DIFF
--- a/backend/briefing.py
+++ b/backend/briefing.py
@@ -1,0 +1,336 @@
+"""Morning briefing (Phase 6 of docs/SPARK_V2_SPEC.md) — narrow, once-a-day
+proactivity. On the first voice activity of a calendar day (or app launch
+after MIN_BRIEFING_HOUR, whichever comes first), Spark opens with a short
+spoken summary of today's calendar events, due/overdue reminders, and the
+weather, instead of waiting to be asked.
+
+Calendar/Reminders are queried directly via osascript rather than through
+Claude's tool-use loop — this needs to run deterministically at startup, not
+depend on the model deciding to call a tool. Weather is a single keyless
+Open-Meteo call; the only Claude API call here is the final one-shot
+composition of the spoken summary from that gathered data.
+"""
+
+import datetime
+import json
+import os
+import subprocess
+
+import requests
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+import protocol
+import ws_server
+
+load_dotenv()
+
+CONFIG_PATH = os.path.expanduser("~/.spark/config.json")
+
+_DEFAULT_CONFIG = {
+    "briefing_enabled": True,
+    "last_briefing_date": None,
+    "location": None,
+}
+
+# "App launch after 5 a.m." per the spec — local time. Guards against a
+# briefing firing on a very-early launch before the day's calendar/reminders
+# are meaningfully settled.
+MIN_BRIEFING_HOUR = 5
+
+# AppleScript calendar/reminders queries can be slow with several
+# calendars/lists — same rationale as claude_client.py's
+# SHELL_COMMAND_TIMEOUT for osascript calls.
+_OSASCRIPT_TIMEOUT = 45
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        _client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    return _client
+
+
+def _read_config() -> dict:
+    if not os.path.exists(CONFIG_PATH):
+        return dict(_DEFAULT_CONFIG)
+    try:
+        with open(CONFIG_PATH) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return dict(_DEFAULT_CONFIG)
+    return {**_DEFAULT_CONFIG, **data}
+
+
+def _write_config(config: dict) -> None:
+    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    with open(CONFIG_PATH, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def _today_str() -> str:
+    return datetime.date.today().isoformat()
+
+
+def should_deliver_briefing(config: dict = None) -> bool:
+    config = config if config is not None else _read_config()
+    if not config.get("briefing_enabled", True):
+        return False
+    if config.get("last_briefing_date") == _today_str():
+        return False
+    if datetime.datetime.now().hour < MIN_BRIEFING_HOUR:
+        return False
+    return True
+
+
+_CALENDAR_SCRIPT = '''
+tell application "Calendar"
+    set todayStart to current date
+    set time of todayStart to 0
+    set todayEnd to todayStart + 1 * days
+    set eventList to {}
+    repeat with cal in calendars
+        try
+            set calEvents to (every event of cal whose start date ≥ todayStart and start date < todayEnd)
+            repeat with ev in calEvents
+                set end of eventList to (summary of ev as string) & " at " & (time string of (start date of ev))
+            end repeat
+        end try
+    end repeat
+    return eventList
+end tell
+'''
+
+_REMINDERS_SCRIPT = '''
+tell application "Reminders"
+    set todayEnd to current date
+    set time of todayEnd to 0
+    set todayEnd to todayEnd + 1 * days
+    set reminderList to {}
+    repeat with lst in lists
+        try
+            set dueReminders to (reminders of lst whose completed is false and due date is not missing value and due date < todayEnd)
+            repeat with r in dueReminders
+                set end of reminderList to (name of r as string)
+            end repeat
+        end try
+    end repeat
+    return reminderList
+end tell
+'''
+
+
+def _run_osascript(script: str, permission_hint: str, empty_text: str, timeout_text: str, error_text: str) -> str:
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True, text=True, timeout=_OSASCRIPT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return timeout_text
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        # -1743 is macOS's AppleEvent "not authorized" error code — the same
+        # class of gap as claude_client.py's screenshot-permission handling:
+        # surface it as a fixable condition, not a silent/permanent failure.
+        if "not allowed" in stderr.lower() or "-1743" in stderr:
+            return permission_hint
+        return error_text
+
+    text = result.stdout.strip()
+    return text if text else empty_text
+
+
+def _get_todays_calendar_events() -> str:
+    return _run_osascript(
+        _CALENDAR_SCRIPT,
+        permission_hint="Calendar access hasn't been granted yet (System Settings > Privacy & Security > Calendars).",
+        empty_text="No events today.",
+        timeout_text="Calendar lookup timed out.",
+        error_text="Couldn't read the calendar.",
+    )
+
+
+def _get_due_reminders() -> str:
+    return _run_osascript(
+        _REMINDERS_SCRIPT,
+        permission_hint="Reminders access hasn't been granted yet (System Settings > Privacy & Security > Reminders).",
+        empty_text="No reminders due.",
+        timeout_text="Reminders lookup timed out.",
+        error_text="Couldn't read reminders.",
+    )
+
+
+def _fetch_ipapi_co():
+    response = requests.get("https://ipapi.co/json/", timeout=5)
+    response.raise_for_status()
+    data = response.json()
+    if data.get("error"):
+        raise ValueError(data.get("reason", "ipapi.co error"))
+    return {
+        "lat": data["latitude"],
+        "lon": data["longitude"],
+        "place": data.get("city") or data.get("region") or "your area",
+    }
+
+
+def _fetch_ip_api_com():
+    # HTTP-only on the free tier (HTTPS requires a paid plan) — used only as
+    # a fallback when ipapi.co is unavailable (found live: its free tier
+    # rate-limits aggressively), and only ever returns approximate
+    # city-level location, not anything sensitive.
+    response = requests.get("http://ip-api.com/json/", timeout=5)
+    response.raise_for_status()
+    data = response.json()
+    if data.get("status") != "success":
+        raise ValueError(data.get("message", "ip-api.com error"))
+    return {
+        "lat": data["lat"],
+        "lon": data["lon"],
+        "place": data.get("city") or data.get("regionName") or "your area",
+    }
+
+
+def _get_location(config: dict):
+    """Cached in config.json after the first successful lookup so briefings
+    after the first don't re-hit either geolocation service. Returns None
+    (rather than raising) if both providers fail — weather is a nice-to-have,
+    not something that should ever block the rest of the briefing.
+    """
+    location = config.get("location")
+    if location:
+        return location
+
+    location = None
+    for fetch in (_fetch_ipapi_co, _fetch_ip_api_com):
+        try:
+            location = fetch()
+            break
+        except Exception as e:
+            print(f"[Briefing] {fetch.__name__} lookup failed: {e}")
+    if location is None:
+        return None
+
+    config["location"] = location
+    _write_config(config)
+    return location
+
+
+# WMO weather interpretation codes (Open-Meteo's `weather_code` field) —
+# only the common ones; anything unmapped just omits the condition phrase
+# rather than guessing.
+_WEATHER_CODES = {
+    0: "clear sky", 1: "mostly clear", 2: "partly cloudy", 3: "overcast",
+    45: "foggy", 48: "foggy",
+    51: "light drizzle", 53: "drizzle", 55: "heavy drizzle",
+    61: "light rain", 63: "rain", 65: "heavy rain",
+    71: "light snow", 73: "snow", 75: "heavy snow",
+    80: "rain showers", 81: "rain showers", 82: "heavy rain showers",
+    95: "thunderstorms", 96: "thunderstorms", 99: "severe thunderstorms",
+}
+
+
+def _get_weather(config: dict) -> str:
+    location = _get_location(config)
+    if location is None:
+        return "Weather unavailable."
+    try:
+        response = requests.get(
+            "https://api.open-meteo.com/v1/forecast",
+            params={
+                "latitude": location["lat"],
+                "longitude": location["lon"],
+                "current": "temperature_2m,weather_code",
+                "daily": "temperature_2m_max,temperature_2m_min",
+                "temperature_unit": "fahrenheit",
+                "timezone": "auto",
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        data = response.json()
+        current_temp = data["current"]["temperature_2m"]
+        condition = _WEATHER_CODES.get(data["current"]["weather_code"], "")
+        high = data["daily"]["temperature_2m_max"][0]
+        low = data["daily"]["temperature_2m_min"][0]
+        return (
+            f"Currently {current_temp:.0f}°F"
+            f"{' and ' + condition if condition else ''} in {location['place']}, "
+            f"with a high of {high:.0f}°F and a low of {low:.0f}°F today."
+        )
+    except Exception as e:
+        print(f"[Briefing] Weather lookup failed: {e}")
+        return "Weather unavailable."
+
+
+_BRIEFING_SYSTEM_PROMPT = (
+    "You are composing a short spoken morning briefing for the user, to be "
+    "read aloud by a voice assistant. Using the information below, write at "
+    "most 4 natural, conversational sentences covering the weather, today's "
+    "calendar events, and any due or overdue reminders. Skip a category "
+    "entirely if there's nothing in it rather than saying \"no events\" -- "
+    "only mention what's actually there. Do not use lists, headers, or "
+    "markdown -- this is read aloud as plain speech."
+)
+
+
+def _compose_briefing_text(calendar_text: str, reminders_text: str, weather_text: str) -> str:
+    response = _get_client().messages.create(
+        model="claude-sonnet-5",
+        max_tokens=300,
+        system=_BRIEFING_SYSTEM_PROMPT,
+        messages=[{
+            "role": "user",
+            "content": (
+                f"Weather: {weather_text}\n\n"
+                f"Today's calendar events: {calendar_text}\n\n"
+                f"Due/overdue reminders: {reminders_text}"
+            ),
+        }],
+    )
+    if response.stop_reason == "refusal":
+        return ""
+    return "".join(block.text for block in response.content if block.type == "text").strip()
+
+
+def maybe_deliver_briefing(speak_fn=None) -> bool:
+    """Delivers the once-a-day morning briefing if conditions are met
+    (enabled, not yet given today, past MIN_BRIEFING_HOUR local). Returns
+    True if a briefing was actually delivered.
+    """
+    config = _read_config()
+    if not should_deliver_briefing(config):
+        return False
+
+    # Marked done immediately, before any of the gathering below (which
+    # calls out to macOS apps and two external services and can fail in any
+    # number of ways) -- a mid-gather crash or a denied permission should
+    # not leave the briefing re-attempting on every subsequent turn for the
+    # rest of the day. Best-effort, once per day, not best-effort-until-it-
+    # works.
+    config["last_briefing_date"] = _today_str()
+    _write_config(config)
+
+    try:
+        calendar_text = _get_todays_calendar_events()
+        reminders_text = _get_due_reminders()
+        weather_text = _get_weather(config)
+        text = _compose_briefing_text(calendar_text, reminders_text, weather_text)
+    except Exception as e:
+        print(f"[Briefing] Failed to compose morning briefing: {e}")
+        return False
+
+    if not text:
+        return False
+
+    # Broadcast before speaking, not after: speak_fn blocks until TTS
+    # playback actually finishes (many seconds for a multi-sentence
+    # briefing), and the panel should show the text as it starts being
+    # spoken, not only once it's already fully done.
+    ws_server.broadcast(protocol.briefing_message(text))
+    if speak_fn:
+        speak_fn(text)
+    return True

--- a/backend/briefing.py
+++ b/backend/briefing.py
@@ -11,10 +11,12 @@ Open-Meteo call; the only Claude API call here is the final one-shot
 composition of the spoken summary from that gathered data.
 """
 
+import concurrent.futures
 import datetime
 import json
 import os
 import subprocess
+import time
 
 import requests
 from anthropic import Anthropic
@@ -85,23 +87,35 @@ def should_deliver_briefing(config: dict = None) -> bool:
     return True
 
 
-_CALENDAR_SCRIPT = '''
-tell application "Calendar"
-    set todayStart to current date
-    set time of todayStart to 0
-    set todayEnd to todayStart + 1 * days
-    set eventList to {}
-    repeat with cal in calendars
-        try
-            set calEvents to (every event of cal whose start date ≥ todayStart and start date < todayEnd)
-            repeat with ev in calEvents
-                set end of eventList to (summary of ev as string) & " at " & (time string of (start date of ev))
-            end repeat
-        end try
-    end repeat
-    return eventList
-end tell
-'''
+_CALENDAR_NAMES_SCRIPT = 'tell application "Calendar" to return (name of every calendar)'
+
+# Bound on a single calendar's own event query. Found live: querying all
+# calendars in one combined "whose start date >= X" AppleScript query (the
+# original approach) reliably took the full _OSASCRIPT_TIMEOUT (45s) because
+# two holiday-subscription calendars alone accounted for ~28s of it --
+# Calendar.app's "whose" date-range filter isn't indexed, so it has to
+# evaluate/expand every occurrence of every recurring event (holiday
+# calendars are the classic pathological case: years of annually-recurring
+# all-day entries) to decide whether any single occurrence falls in today's
+# range. Querying each calendar separately bounds one slow calendar's cost
+# to its own timeout rather than the whole lookup.
+#
+# Deliberately sequential, not concurrent, despite that being the first fix
+# attempted here: querying calendars via a ThreadPoolExecutor made things
+# *worse*, not better -- found live that even 2 concurrent osascript calls
+# against Calendar.app caused a calendar that normally answers in ~8s to
+# time out entirely. Calendar.app appears to serialize its own Apple Events
+# handling internally, so concurrent client requests contend with each other
+# rather than actually running in parallel. _CALENDAR_TOTAL_BUDGET below is
+# what actually bounds worst-case wall-clock time here, not concurrency.
+_PER_CALENDAR_TIMEOUT = 10
+
+# Hard ceiling on the whole calendar section of the briefing, regardless of
+# how many calendars exist or how many are individually slow -- once this
+# much time has been spent, remaining not-yet-queried calendars are skipped
+# (same "contributes nothing this time" degradation as a single timed-out
+# calendar) rather than trying all of them unconditionally.
+_CALENDAR_TOTAL_BUDGET = 20
 
 _REMINDERS_SCRIPT = '''
 tell application "Reminders"
@@ -144,14 +158,105 @@ def _run_osascript(script: str, permission_hint: str, empty_text: str, timeout_t
     return text if text else empty_text
 
 
+def _get_calendar_names():
+    """(names, error_text). names is None if the calendar list itself
+    couldn't be fetched (permission/timeout/other failure) -- check
+    error_text in that case, a plain list (possibly empty) otherwise. This
+    call alone is fast (no date-range "whose" filter involved), so it uses a
+    short fixed timeout rather than _PER_CALENDAR_TIMEOUT.
+    """
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", _CALENDAR_NAMES_SCRIPT],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "Calendar lookup timed out."
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "not allowed" in stderr.lower() or "-1743" in stderr:
+            return None, "Calendar access hasn't been granted yet (System Settings > Privacy & Security > Calendars)."
+        return None, "Couldn't read the calendar."
+
+    text = result.stdout.strip()
+    if not text:
+        return [], None
+    return [name.strip() for name in text.split(",") if name.strip()], None
+
+
+def _events_for_one_calendar(name: str, timeout: float = _PER_CALENDAR_TIMEOUT) -> str:
+    """Today's events for a single named calendar, as osascript's natural
+    comma-joined list-to-string coercion (possibly empty). Failures
+    (including a timeout) return "" rather than propagating -- one
+    problem calendar should degrade to "its events are missing", not take
+    down the whole calendar section of the briefing. timeout is overridable
+    so _get_todays_calendar_events can clamp it to whatever's left of the
+    overall budget for the last calendar or two it attempts.
+    """
+    escaped = name.replace('"', '\\"')
+    script = f'''
+tell application "Calendar"
+    set todayStart to current date
+    set time of todayStart to 0
+    set todayEnd to todayStart + 1 * days
+    set eventList to {{}}
+    set calEvents to (every event of calendar "{escaped}" whose start date ≥ todayStart and start date < todayEnd)
+    repeat with ev in calEvents
+        set end of eventList to (summary of ev as string) & " at " & (time string of (start date of ev))
+    end repeat
+    return eventList
+end tell
+'''
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"[Briefing] Calendar '{name}' timed out, skipping its events.")
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
 def _get_todays_calendar_events() -> str:
-    return _run_osascript(
-        _CALENDAR_SCRIPT,
-        permission_hint="Calendar access hasn't been granted yet (System Settings > Privacy & Security > Calendars).",
-        empty_text="No events today.",
-        timeout_text="Calendar lookup timed out.",
-        error_text="Couldn't read the calendar.",
-    )
+    names, error = _get_calendar_names()
+    if names is None:
+        return error
+    if not names:
+        return "No events today."
+
+    # Holiday-subscription calendars are the observed pathological case
+    # (years of annually-recurring all-day entries make Calendar.app's
+    # "whose" date filter extremely slow to evaluate) -- found live that
+    # they happened to sit early enough in Calendar.app's own ordering that
+    # the time budget below got spent on them before even reaching fast,
+    # actually-relevant calendars like Work or Home. Trying non-holiday-
+    # named calendars first means the budget is spent on calendars that are
+    # both faster and more likely to matter for a daily briefing before it's
+    # spent on ones that are neither. `sorted` is stable, so the relative
+    # order within each group still matches Calendar.app's own ordering.
+    names = sorted(names, key=lambda n: "holiday" in n.lower())
+
+    results = []
+    deadline = time.monotonic() + _CALENDAR_TOTAL_BUDGET
+    for name in names:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            skipped = names[len(results):]
+            print(f"[Briefing] Calendar time budget exhausted, skipping: {skipped}")
+            break
+        # Clamped to whatever's actually left so the last calendar attempted
+        # can't blow past _CALENDAR_TOTAL_BUDGET on its own -- without this,
+        # a calendar started just before the deadline could still run for
+        # its full _PER_CALENDAR_TIMEOUT regardless of how little budget
+        # remained.
+        results.append(_events_for_one_calendar(name, timeout=min(_PER_CALENDAR_TIMEOUT, remaining)))
+
+    events_text = ", ".join(text for text in results if text)
+    return events_text if events_text else "No events today."
 
 
 def _get_due_reminders() -> str:
@@ -296,35 +401,66 @@ def _compose_briefing_text(calendar_text: str, reminders_text: str, weather_text
     return "".join(block.text for block in response.content if block.type == "text").strip()
 
 
-def maybe_deliver_briefing(speak_fn=None) -> bool:
-    """Delivers the once-a-day morning briefing if conditions are met
-    (enabled, not yet given today, past MIN_BRIEFING_HOUR local). Returns
-    True if a briefing was actually delivered.
+def _gather_briefing_inputs(config: dict):
+    """Runs the calendar, reminders, and weather lookups concurrently —
+    they're independent of each other, so running them one after another
+    (as this originally did) only adds unnecessary wall-clock time, and the
+    calendar lookup in particular can be slow (up to _OSASCRIPT_TIMEOUT).
+    Returns (calendar_text, reminders_text, weather_text).
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        calendar_future = executor.submit(_get_todays_calendar_events)
+        reminders_future = executor.submit(_get_due_reminders)
+        weather_future = executor.submit(_get_weather, config)
+        return calendar_future.result(), reminders_future.result(), weather_future.result()
+
+
+def prepare_briefing_text() -> str:
+    """Gathers and composes the briefing text if conditions are met (see
+    should_deliver_briefing), WITHOUT marking it delivered, broadcasting, or
+    speaking it. Returns "" if conditions aren't met or gathering/
+    composition failed — never None, so callers can treat the return value
+    as a plain truthy/falsy check.
+
+    Deliberately separate from delivery: call this as early as possible
+    (e.g. from a background thread started right at process launch, before
+    Whisper/Kokoro model loading and VAD calibration) so the gathering —
+    two osascript calls, a weather API call, and one Claude call, all
+    network/IO-bound — overlaps with the rest of app startup instead of
+    adding to the wait after the app is already listening and the user
+    could start talking. See spark_whisper_mic.py's module-level prefetch
+    thread and its use of deliver_prepared_briefing below.
+    """
+    config = _read_config()
+    if not should_deliver_briefing(config):
+        return ""
+    try:
+        calendar_text, reminders_text, weather_text = _gather_briefing_inputs(config)
+        text = _compose_briefing_text(calendar_text, reminders_text, weather_text)
+    except Exception as e:
+        print(f"[Briefing] Failed to compose morning briefing: {e}")
+        return ""
+    return text
+
+
+def deliver_prepared_briefing(text: str, speak_fn=None) -> bool:
+    """Marks today's briefing delivered, broadcasts it, and speaks it. Call
+    with the (non-empty) result of prepare_briefing_text() — skip entirely
+    if that returned "". Re-checks should_deliver_briefing first so text
+    prepared early doesn't get delivered twice if something else already
+    delivered today's briefing in the meantime (the two trigger sites in
+    spark_whisper_mic.py can otherwise race).
     """
     config = _read_config()
     if not should_deliver_briefing(config):
         return False
 
-    # Marked done immediately, before any of the gathering below (which
-    # calls out to macOS apps and two external services and can fail in any
-    # number of ways) -- a mid-gather crash or a denied permission should
-    # not leave the briefing re-attempting on every subsequent turn for the
-    # rest of the day. Best-effort, once per day, not best-effort-until-it-
-    # works.
+    # Marked done before broadcasting/speaking (not after) so a failure in
+    # either doesn't leave the briefing re-attempting later today — matches
+    # prepare_briefing_text's own best-effort-once, not
+    # best-effort-until-it-works, stance on its half of the work.
     config["last_briefing_date"] = _today_str()
     _write_config(config)
-
-    try:
-        calendar_text = _get_todays_calendar_events()
-        reminders_text = _get_due_reminders()
-        weather_text = _get_weather(config)
-        text = _compose_briefing_text(calendar_text, reminders_text, weather_text)
-    except Exception as e:
-        print(f"[Briefing] Failed to compose morning briefing: {e}")
-        return False
-
-    if not text:
-        return False
 
     # Broadcast before speaking, not after: speak_fn blocks until TTS
     # playback actually finishes (many seconds for a multi-sentence
@@ -334,3 +470,17 @@ def maybe_deliver_briefing(speak_fn=None) -> bool:
     if speak_fn:
         speak_fn(text)
     return True
+
+
+def maybe_deliver_briefing(speak_fn=None) -> bool:
+    """All-in-one convenience entry point: gather, compose, mark delivered,
+    broadcast, and speak, in one call. Used by the "first real utterance of
+    the day" fallback trigger, where there's no earlier point to prefetch
+    from. For the app-launch trigger, prefer prepare_briefing_text() (called
+    as early as possible) + deliver_prepared_briefing(), so the gathering
+    overlaps with other startup work instead of stacking after it.
+    """
+    text = prepare_briefing_text()
+    if not text:
+        return False
+    return deliver_prepared_briefing(text, speak_fn=speak_fn)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ pyttsx3==2.99
 websockets==16.0
 kokoro==0.9.4
 sentence-transformers==3.3.1
+requests==2.34.2
 
 # dev/test
 pytest==9.1.1

--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -144,6 +144,24 @@ def calibrate_vad_threshold(duration=2.0):
 
 print = functools.partial(print, flush=True)
 
+# Phase 6: start gathering+composing the morning briefing (if today's
+# conditions call for one) on a background thread as early in startup as
+# possible — before Kokoro/Whisper model loading and VAD calibration below,
+# not after. Those are the only other things startup is doing before Spark
+# is actually "live", so this overlaps the briefing's network/IO-bound work
+# (osascript calls, weather, one Claude call) with them instead of adding to
+# the wait once the app is already ready and the user could start talking.
+# main() joins this thread and delivers whatever it produced — see there for
+# why this is a plain dict rather than a return value (the thread itself has
+# nowhere to return one to).
+_briefing_prefetch = {}
+
+def _prefetch_briefing():
+    _briefing_prefetch["text"] = briefing.prepare_briefing_text()
+
+briefing_prefetch_thread = threading.Thread(target=_prefetch_briefing, daemon=True)
+briefing_prefetch_thread.start()
+
 # Kokoro is the primary engine (chosen after a direct side-by-side listening
 # comparison against pyttsx3); pyttsx3 stays available as a fallback behind
 # the same interface if Kokoro's dependencies aren't installed.
@@ -575,12 +593,22 @@ def main():
 
     write_status("listening")
 
-    # Covers "app launch after 5 a.m." (Phase 6) -- the other stated trigger,
-    # "first voice activity of the day", is checked again below at the first
-    # real utterance, for the case of a long-running session that crosses
-    # midnight without a restart. Both call the same idempotent function, so
-    # it can only actually fire once per day regardless of which one wins.
-    briefing.maybe_deliver_briefing(speak_fn=speak_briefing)
+    # Covers "app launch after 5 a.m." (Phase 6). The gathering already
+    # happened (or is close to done) on briefing_prefetch_thread, started at
+    # module load before Whisper/Kokoro warmup and VAD calibration — join
+    # rather than re-gathering from scratch here, so whatever wait remains
+    # is only however much of it didn't fit inside that other startup work,
+    # not the full gather+compose time on top of an already-ready app. The
+    # other stated trigger, "first voice activity of the day", is checked
+    # again below at the first real utterance, for the case of a
+    # long-running session that crosses midnight without a restart --
+    # deliver_prepared_briefing/maybe_deliver_briefing both re-check
+    # should_deliver_briefing, so only one of the two trigger sites can
+    # actually deliver on a given day regardless of which fires first.
+    briefing_prefetch_thread.join(timeout=60)
+    prefetched_briefing_text = _briefing_prefetch.get("text")
+    if prefetched_briefing_text:
+        briefing.deliver_prepared_briefing(prefetched_briefing_text, speak_fn=speak_briefing)
 
     while True:
         if not transcript_queue.empty():

--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -587,28 +587,32 @@ def main():
     chat_history = store.load_recent_messages(_db, limit=20)
     turn_count = 0
 
+    # Phase 6: deliver the morning briefing (if today's conditions call for
+    # one) BEFORE starting the mic listener / typed-input watcher, or
+    # announcing "listening" at all. If Spark were already accepting input
+    # while the briefing was still being gathered or spoken, anything the
+    # user said in that window would sit unanswered until the briefing
+    # finished — reading as Spark ignoring them and then barging in with a
+    # briefing over an unaddressed request. Blocking here instead means
+    # nothing is capturing input until the briefing is fully done, so there
+    # is no window for that confusion.
+    #
+    # This doesn't add wait time on top of what's already there: the
+    # gathering itself started as early as possible, on
+    # briefing_prefetch_thread at module load — before Kokoro/Whisper
+    # warmup and VAD calibration above even ran — so this join only waits
+    # for whatever of that work didn't already finish during that other
+    # startup time.
+    briefing_prefetch_thread.join(timeout=60)
+    prefetched_briefing_text = _briefing_prefetch.get("text")
+    if prefetched_briefing_text:
+        briefing.deliver_prepared_briefing(prefetched_briefing_text, speak_fn=speak_briefing)
+
     transcript_queue = queue.Queue()
     threading.Thread(target=mic_listener, args=(transcript_queue,), daemon=True).start()
     threading.Thread(target=incoming_message_watcher, args=(transcript_queue,), daemon=True).start()
 
     write_status("listening")
-
-    # Covers "app launch after 5 a.m." (Phase 6). The gathering already
-    # happened (or is close to done) on briefing_prefetch_thread, started at
-    # module load before Whisper/Kokoro warmup and VAD calibration — join
-    # rather than re-gathering from scratch here, so whatever wait remains
-    # is only however much of it didn't fit inside that other startup work,
-    # not the full gather+compose time on top of an already-ready app. The
-    # other stated trigger, "first voice activity of the day", is checked
-    # again below at the first real utterance, for the case of a
-    # long-running session that crosses midnight without a restart --
-    # deliver_prepared_briefing/maybe_deliver_briefing both re-check
-    # should_deliver_briefing, so only one of the two trigger sites can
-    # actually deliver on a given day regardless of which fires first.
-    briefing_prefetch_thread.join(timeout=60)
-    prefetched_briefing_text = _briefing_prefetch.get("text")
-    if prefetched_briefing_text:
-        briefing.deliver_prepared_briefing(prefetched_briefing_text, speak_fn=speak_briefing)
 
     while True:
         if not transcript_queue.empty():
@@ -620,10 +624,17 @@ def main():
             # them would ever match real transcribed speech.
             stripped_line = normalized_line.strip(".,!?")
 
-            # First real utterance of the day (see the launch-time check
-            # above for the other trigger) -- takes priority over even
-            # clear-history, since it's not a response to anything the user
-            # said, just an interstitial before normal processing continues.
+            # Fallback for a long-running session that crosses midnight
+            # without a restart (the launch-time delivery above only covers
+            # a fresh launch on the new day). This one genuinely can
+            # interrupt an in-progress interaction -- by the time any
+            # utterance reaches this point the mic has already been running
+            # since launch, so unlike the launch-time case there's no way to
+            # guarantee nothing was mid-flight. Accepted as a rare edge case
+            # (a session spanning two calendar days) rather than something
+            # worth complicating the common path for; is a no-op on every
+            # ordinary day since the launch-time delivery already marked
+            # today done.
             briefing.maybe_deliver_briefing(speak_fn=speak_briefing)
 
             if stripped_line in CLEAR_HISTORY_PHRASES:

--- a/backend/spark_whisper_mic.py
+++ b/backend/spark_whisper_mic.py
@@ -17,6 +17,7 @@ import ws_server
 import protocol
 import store
 import memory
+import briefing
 import audio_bands
 import confirmation_gate
 import mic_control
@@ -396,6 +397,24 @@ def speak_reply(text, show_popup=False):
     _post_speech_cleanup()
 
 
+def speak_briefing(text):
+    """Like speak_reply, but doesn't also broadcast the text as a generic
+    assistant reply (write_status's text= param does that as a side effect).
+    The morning briefing (Phase 6) has its own dedicated protocol message
+    and labeled UI treatment — briefing.py broadcasts protocol.briefing_
+    message() itself, before calling this — so going through write_status's
+    text param here too would show the same text twice: once unlabeled
+    (immediately, via the generic assistant_chunk path) and once labeled
+    (only after TTS finishes, since that broadcast happens after speak_fn
+    returns).
+    """
+    write_status("speaking")
+
+    mic_control.mute_microphone()
+    tts_engine.speak_stream(iter([text]))
+    _post_speech_cleanup()
+
+
 def incoming_message_watcher(transcript_queue):
     """Watches messages the frontend sends back over the WebSocket:
     - interrupt: tap-to-interrupt (Phase 2) — stop whatever TTS is playing.
@@ -556,6 +575,13 @@ def main():
 
     write_status("listening")
 
+    # Covers "app launch after 5 a.m." (Phase 6) -- the other stated trigger,
+    # "first voice activity of the day", is checked again below at the first
+    # real utterance, for the case of a long-running session that crosses
+    # midnight without a restart. Both call the same idempotent function, so
+    # it can only actually fire once per day regardless of which one wins.
+    briefing.maybe_deliver_briefing(speak_fn=speak_briefing)
+
     while True:
         if not transcript_queue.empty():
             line = transcript_queue.get().strip()
@@ -565,6 +591,12 @@ def main():
             # form rather than normalized_line directly — otherwise none of
             # them would ever match real transcribed speech.
             stripped_line = normalized_line.strip(".,!?")
+
+            # First real utterance of the day (see the launch-time check
+            # above for the other trigger) -- takes priority over even
+            # clear-history, since it's not a response to anything the user
+            # said, just an interstitial before normal processing continues.
+            briefing.maybe_deliver_briefing(speak_fn=speak_briefing)
 
             if stripped_line in CLEAR_HISTORY_PHRASES:
                 cancel_idle_timer()

--- a/backend/tests/test_briefing.py
+++ b/backend/tests/test_briefing.py
@@ -1,0 +1,341 @@
+import datetime
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import briefing
+
+
+class _FakeDate:
+    @staticmethod
+    def today():
+        return datetime.date(2026, 7, 12)
+
+
+class _FakeDateTime:
+    @staticmethod
+    def now():
+        return datetime.datetime(2026, 7, 12, 8, 0)
+
+
+class _FakeDatetimeModule:
+    date = _FakeDate
+    datetime = _FakeDateTime
+
+
+def _freeze_time(monkeypatch, hour=8):
+    class _DT:
+        @staticmethod
+        def now():
+            return datetime.datetime(2026, 7, 12, hour, 0)
+
+    class _Mod:
+        date = _FakeDate
+        datetime = _DT
+
+    monkeypatch.setattr(briefing, "datetime", _Mod)
+
+
+def _isolate_config(monkeypatch, tmp_path):
+    monkeypatch.setattr(briefing, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+
+# --- config read/write -------------------------------------------------------
+
+
+def test_read_config_returns_defaults_when_missing(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    config = briefing._read_config()
+    assert config == briefing._DEFAULT_CONFIG
+
+
+def test_write_then_read_config_roundtrips(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    briefing._write_config({"briefing_enabled": False, "last_briefing_date": "2026-07-11", "location": None})
+    config = briefing._read_config()
+    assert config["briefing_enabled"] is False
+    assert config["last_briefing_date"] == "2026-07-11"
+
+
+def test_read_config_survives_corrupt_file(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    os.makedirs(tmp_path, exist_ok=True)
+    with open(briefing.CONFIG_PATH, "w") as f:
+        f.write("not valid json{{{")
+    assert briefing._read_config() == briefing._DEFAULT_CONFIG
+
+
+# --- should_deliver_briefing --------------------------------------------------
+
+
+def test_should_deliver_when_enabled_not_yet_briefed_and_past_hour(monkeypatch):
+    _freeze_time(monkeypatch, hour=8)
+    config = {"briefing_enabled": True, "last_briefing_date": None, "location": None}
+    assert briefing.should_deliver_briefing(config) is True
+
+
+def test_should_not_deliver_when_disabled(monkeypatch):
+    _freeze_time(monkeypatch, hour=8)
+    config = {"briefing_enabled": False, "last_briefing_date": None, "location": None}
+    assert briefing.should_deliver_briefing(config) is False
+
+
+def test_should_not_deliver_when_already_briefed_today(monkeypatch):
+    _freeze_time(monkeypatch, hour=8)
+    config = {"briefing_enabled": True, "last_briefing_date": "2026-07-12", "location": None}
+    assert briefing.should_deliver_briefing(config) is False
+
+
+def test_should_deliver_when_last_briefing_was_a_different_day(monkeypatch):
+    _freeze_time(monkeypatch, hour=8)
+    config = {"briefing_enabled": True, "last_briefing_date": "2026-07-11", "location": None}
+    assert briefing.should_deliver_briefing(config) is True
+
+
+def test_should_not_deliver_before_min_hour(monkeypatch):
+    _freeze_time(monkeypatch, hour=3)
+    config = {"briefing_enabled": True, "last_briefing_date": None, "location": None}
+    assert briefing.should_deliver_briefing(config) is False
+
+
+# --- osascript wrapper ---------------------------------------------------------
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_run_osascript_returns_stdout_on_success(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=0, stdout="Standup at 9:30am"),
+    )
+    result = briefing._run_osascript("script", "denied", "empty", "timeout", "error")
+    assert result == "Standup at 9:30am"
+
+
+def test_run_osascript_returns_empty_text_for_blank_stdout(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeCompletedProcess(returncode=0, stdout="   "))
+    result = briefing._run_osascript("script", "denied", "empty", "timeout", "error")
+    assert result == "empty"
+
+
+def test_run_osascript_detects_permission_denial(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=1, stderr="Not authorized (-1743)"),
+    )
+    result = briefing._run_osascript("script", "denied", "empty", "timeout", "error")
+    assert result == "denied"
+
+
+def test_run_osascript_handles_timeout(monkeypatch):
+    def _raise(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="osascript", timeout=45)
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    result = briefing._run_osascript("script", "denied", "empty", "timeout", "error")
+    assert result == "timeout"
+
+
+def test_run_osascript_generic_failure(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=1, stderr="something else went wrong"),
+    )
+    result = briefing._run_osascript("script", "denied", "empty", "timeout", "error")
+    assert result == "error"
+
+
+# --- location / weather --------------------------------------------------------
+
+
+class _FakeHTTPResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_get_location_caches_after_first_lookup(monkeypatch):
+    import requests
+
+    calls = []
+
+    def _fake_get(url, **kwargs):
+        calls.append(url)
+        return _FakeHTTPResponse({"latitude": 42.0, "longitude": -71.0, "city": "Boston"})
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+    config = {"briefing_enabled": True, "last_briefing_date": None, "location": None}
+    monkeypatch.setattr(briefing, "_write_config", lambda c: None)
+
+    first = briefing._get_location(config)
+    second = briefing._get_location(config)
+
+    assert first == {"lat": 42.0, "lon": -71.0, "place": "Boston"}
+    assert second == first
+    assert len(calls) == 1  # second call served from the now-populated config, no new request
+
+
+def test_get_location_returns_none_on_failure(monkeypatch):
+    import requests
+
+    def _raise(*a, **kw):
+        raise ConnectionError("no network")
+
+    monkeypatch.setattr(requests, "get", _raise)
+    config = {"briefing_enabled": True, "last_briefing_date": None, "location": None}
+    assert briefing._get_location(config) is None
+
+
+def test_get_weather_formats_current_and_forecast(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(briefing, "_get_location", lambda config: {"lat": 42.0, "lon": -71.0, "place": "Boston"})
+
+    def _fake_get(url, **kwargs):
+        return _FakeHTTPResponse({
+            "current": {"temperature_2m": 68.4, "weather_code": 1},
+            "daily": {"temperature_2m_max": [72.1], "temperature_2m_min": [55.6]},
+        })
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+    text = briefing._get_weather({})
+    assert "68" in text
+    assert "mostly clear" in text
+    assert "Boston" in text
+    assert "72" in text and "56" in text
+
+
+def test_get_weather_unavailable_when_location_missing(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_location", lambda config: None)
+    assert briefing._get_weather({}) == "Weather unavailable."
+
+
+def test_get_weather_unavailable_on_request_failure(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(briefing, "_get_location", lambda config: {"lat": 1, "lon": 1, "place": "X"})
+    monkeypatch.setattr(requests, "get", lambda *a, **kw: (_ for _ in ()).throw(ConnectionError("down")))
+    assert briefing._get_weather({}) == "Weather unavailable."
+
+
+# --- composition ---------------------------------------------------------------
+
+
+class _FakeTextBlock:
+    def __init__(self, text):
+        self.type = "text"
+        self.text = text
+
+
+class _FakeResponse:
+    def __init__(self, text, stop_reason="end_turn"):
+        self.content = [_FakeTextBlock(text)]
+        self.stop_reason = stop_reason
+
+
+def _fake_client(response):
+    class _FakeMessages:
+        def create(self, **kwargs):
+            return response
+
+    class _FakeClient:
+        messages = _FakeMessages()
+
+    return _FakeClient()
+
+
+def test_compose_briefing_text_returns_stripped_text(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_client", lambda: _fake_client(_FakeResponse("  Good morning!  ")))
+    text = briefing._compose_briefing_text("no events", "no reminders", "sunny")
+    assert text == "Good morning!"
+
+
+def test_compose_briefing_text_empty_on_refusal(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_client", lambda: _fake_client(_FakeResponse("", stop_reason="refusal")))
+    text = briefing._compose_briefing_text("no events", "no reminders", "sunny")
+    assert text == ""
+
+
+# --- maybe_deliver_briefing (full flow) -----------------------------------------
+
+
+def test_maybe_deliver_briefing_noop_when_conditions_not_met(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=3)  # before MIN_BRIEFING_HOUR
+    calls = []
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: calls.append("calendar") or "x")
+
+    delivered = briefing.maybe_deliver_briefing(speak_fn=lambda t: calls.append(("speak", t)))
+
+    assert delivered is False
+    assert calls == []  # never even started gathering
+
+
+def test_maybe_deliver_briefing_full_success(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=8)
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: "Standup at 9:30am")
+    monkeypatch.setattr(briefing, "_get_due_reminders", lambda: "No reminders due.")
+    monkeypatch.setattr(briefing, "_get_weather", lambda config: "Sunny, 70F.")
+    monkeypatch.setattr(briefing, "_compose_briefing_text", lambda c, r, w: "Good morning! You have standup at 9:30, it's sunny and 70.")
+
+    broadcasts = []
+    monkeypatch.setattr(briefing.ws_server, "broadcast", lambda msg: broadcasts.append(msg))
+    spoken = []
+
+    delivered = briefing.maybe_deliver_briefing(speak_fn=lambda t: spoken.append(t))
+
+    assert delivered is True
+    assert spoken == ["Good morning! You have standup at 9:30, it's sunny and 70."]
+    assert len(broadcasts) == 1
+    assert broadcasts[0]["type"] == "briefing"
+    # Marked done for today so a second call in the same run is a no-op.
+    assert briefing._read_config()["last_briefing_date"] == "2026-07-12"
+
+
+def test_maybe_deliver_briefing_marks_done_even_if_gathering_fails(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=8)
+
+    def _boom():
+        raise RuntimeError("osascript exploded")
+
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", _boom)
+
+    delivered = briefing.maybe_deliver_briefing(speak_fn=lambda t: None)
+
+    assert delivered is False
+    # Still marked as attempted for today -- no retry storm on every turn.
+    assert briefing._read_config()["last_briefing_date"] == "2026-07-12"
+
+
+def test_maybe_deliver_briefing_second_call_same_day_is_noop(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=8)
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: "x")
+    monkeypatch.setattr(briefing, "_get_due_reminders", lambda: "y")
+    monkeypatch.setattr(briefing, "_get_weather", lambda config: "z")
+    monkeypatch.setattr(briefing, "_compose_briefing_text", lambda c, r, w: "Morning!")
+    monkeypatch.setattr(briefing.ws_server, "broadcast", lambda msg: None)
+
+    first = briefing.maybe_deliver_briefing(speak_fn=lambda t: None)
+    calls = []
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: calls.append(1) or "x")
+    second = briefing.maybe_deliver_briefing(speak_fn=lambda t: None)
+
+    assert first is True
+    assert second is False
+    assert calls == []

--- a/backend/tests/test_briefing.py
+++ b/backend/tests/test_briefing.py
@@ -3,6 +3,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -153,6 +154,154 @@ def test_run_osascript_generic_failure(monkeypatch):
     assert result == "error"
 
 
+# --- calendar (per-calendar, parallel) -------------------------------------------
+
+
+def test_get_calendar_names_success(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=0, stdout="Work, Home, Holidays"),
+    )
+    names, error = briefing._get_calendar_names()
+    assert names == ["Work", "Home", "Holidays"]
+    assert error is None
+
+
+def test_get_calendar_names_empty(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeCompletedProcess(returncode=0, stdout="   "))
+    names, error = briefing._get_calendar_names()
+    assert names == []
+    assert error is None
+
+
+def test_get_calendar_names_permission_denied(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=1, stderr="Not authorized (-1743)"),
+    )
+    names, error = briefing._get_calendar_names()
+    assert names is None
+    assert "Calendars" in error
+
+
+def test_get_calendar_names_timeout(monkeypatch):
+    def _raise(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="osascript", timeout=10)
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    names, error = briefing._get_calendar_names()
+    assert names is None
+    assert error == "Calendar lookup timed out."
+
+
+def test_events_for_one_calendar_success(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _FakeCompletedProcess(returncode=0, stdout="Standup at 9:30 AM"),
+    )
+    assert briefing._events_for_one_calendar("Work") == "Standup at 9:30 AM"
+
+
+def test_events_for_one_calendar_timeout_returns_empty_not_raises(monkeypatch):
+    def _raise(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="osascript", timeout=15)
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    # A single pathological calendar (e.g. a holiday subscription with years
+    # of recurring entries -- found live) must degrade to "no events from
+    # this one" rather than raising and taking down the whole lookup.
+    assert briefing._events_for_one_calendar("Holidays in India") == ""
+
+
+def test_events_for_one_calendar_failure_returns_empty(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeCompletedProcess(returncode=1, stderr="boom"))
+    assert briefing._events_for_one_calendar("Work") == ""
+
+
+def test_get_todays_calendar_events_combines_calendars_and_skips_slow_ones(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_calendar_names", lambda: (["Work", "Holidays in India", "Home"], None))
+
+    def _fake_events(name, timeout=None):
+        return {
+            "Work": "Standup at 9:30 AM",
+            "Holidays in India": "",  # simulates a timeout/skip
+            "Home": "Dentist at 2:00 PM",
+        }[name]
+
+    monkeypatch.setattr(briefing, "_events_for_one_calendar", _fake_events)
+
+    text = briefing._get_todays_calendar_events()
+
+    assert "Standup at 9:30 AM" in text
+    assert "Dentist at 2:00 PM" in text
+    # The timed-out calendar simply contributes nothing -- not an error for
+    # the whole lookup, unlike the old single combined-query approach.
+    assert "Holidays" not in text
+
+
+def test_get_todays_calendar_events_no_events_anywhere(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_calendar_names", lambda: (["Work", "Home"], None))
+    monkeypatch.setattr(briefing, "_events_for_one_calendar", lambda name, timeout=None: "")
+
+    assert briefing._get_todays_calendar_events() == "No events today."
+
+
+def test_get_todays_calendar_events_no_calendars_at_all(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_calendar_names", lambda: ([], None))
+
+    assert briefing._get_todays_calendar_events() == "No events today."
+
+
+def test_get_todays_calendar_events_propagates_names_error(monkeypatch):
+    monkeypatch.setattr(
+        briefing, "_get_calendar_names",
+        lambda: (None, "Calendar access hasn't been granted yet (System Settings > Privacy & Security > Calendars)."),
+    )
+
+    assert briefing._get_todays_calendar_events() == (
+        "Calendar access hasn't been granted yet (System Settings > Privacy & Security > Calendars)."
+    )
+
+
+def test_get_todays_calendar_events_processes_sequentially_not_concurrently(monkeypatch):
+    # Found live: concurrent per-calendar queries actively hurt (Calendar.app
+    # appears to serialize Apple Events internally, so concurrent client
+    # requests contend with each other and even normally-fast calendars
+    # started timing out). This locks in "sequential" as a regression guard.
+    monkeypatch.setattr(briefing, "_get_calendar_names", lambda: (["A", "B", "C"], None))
+    order = []
+
+    def _fake_events(name, timeout=None):
+        order.append(name)
+        return f"event from {name}"
+
+    monkeypatch.setattr(briefing, "_events_for_one_calendar", _fake_events)
+
+    briefing._get_todays_calendar_events()
+
+    assert order == ["A", "B", "C"]  # strictly in order, one at a time
+
+
+def test_get_todays_calendar_events_stops_once_time_budget_exhausted(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_calendar_names", lambda: (["Fast", "Slow", "NeverReached"], None))
+    monkeypatch.setattr(briefing, "_CALENDAR_TOTAL_BUDGET", 0.05)
+
+    def _fake_events(name, timeout=None):
+        if name == "Slow":
+            time.sleep(0.1)  # pushes elapsed time past the budget
+        return f"event from {name}"
+
+    monkeypatch.setattr(briefing, "_events_for_one_calendar", _fake_events)
+
+    text = briefing._get_todays_calendar_events()
+
+    assert "Fast" in text
+    assert "Slow" in text
+    # Budget was exhausted by the time "Slow" finished -- "NeverReached" is
+    # never even attempted, not just timed out.
+    assert "NeverReached" not in text
+
+
 # --- location / weather --------------------------------------------------------
 
 
@@ -269,7 +418,115 @@ def test_compose_briefing_text_empty_on_refusal(monkeypatch):
     assert text == ""
 
 
-# --- maybe_deliver_briefing (full flow) -----------------------------------------
+# --- _gather_briefing_inputs (concurrent) ---------------------------------------
+
+
+def test_gather_briefing_inputs_runs_all_three_and_returns_in_order(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: "Standup at 9:30am")
+    monkeypatch.setattr(briefing, "_get_due_reminders", lambda: "No reminders due.")
+    monkeypatch.setattr(briefing, "_get_weather", lambda config: "Sunny, 70F.")
+
+    calendar_text, reminders_text, weather_text = briefing._gather_briefing_inputs({})
+
+    assert calendar_text == "Standup at 9:30am"
+    assert reminders_text == "No reminders due."
+    assert weather_text == "Sunny, 70F."
+
+
+def test_gather_briefing_inputs_propagates_a_failure_from_any_one(monkeypatch):
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(briefing, "_get_due_reminders", lambda: "y")
+    monkeypatch.setattr(briefing, "_get_weather", lambda config: "z")
+
+    try:
+        briefing._gather_briefing_inputs({})
+        assert False, "expected RuntimeError to propagate"
+    except RuntimeError:
+        pass
+
+
+# --- prepare_briefing_text / deliver_prepared_briefing (split API) --------------
+
+
+def test_prepare_briefing_text_noop_when_conditions_not_met(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=3)  # before MIN_BRIEFING_HOUR
+    calls = []
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: calls.append("calendar") or "x")
+
+    text = briefing.prepare_briefing_text()
+
+    assert text == ""
+    assert calls == []  # never even started gathering
+    # No side effects on config either -- nothing was attempted.
+    assert briefing._read_config()["last_briefing_date"] is None
+
+
+def test_prepare_briefing_text_success(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=8)
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: "Standup at 9:30am")
+    monkeypatch.setattr(briefing, "_get_due_reminders", lambda: "No reminders due.")
+    monkeypatch.setattr(briefing, "_get_weather", lambda config: "Sunny, 70F.")
+    monkeypatch.setattr(briefing, "_compose_briefing_text", lambda c, r, w: "Good morning!")
+
+    text = briefing.prepare_briefing_text()
+
+    assert text == "Good morning!"
+    # Preparing does not mark the day as briefed or broadcast/speak anything
+    # -- that's deliver_prepared_briefing's job, so a prefetched-but-not-yet-
+    # delivered text doesn't silently consume today's one briefing.
+    assert briefing._read_config()["last_briefing_date"] is None
+
+
+def test_prepare_briefing_text_empty_on_gathering_failure_and_does_not_mark_done(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=8)
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: (_ for _ in ()).throw(RuntimeError("osascript exploded")))
+    monkeypatch.setattr(briefing, "_get_due_reminders", lambda: "y")
+    monkeypatch.setattr(briefing, "_get_weather", lambda config: "z")
+
+    text = briefing.prepare_briefing_text()
+
+    assert text == ""
+    # Not marked as attempted -- a gather failure allows a retry later today
+    # via the fallback trigger, rather than permanently skipping the day.
+    assert briefing._read_config()["last_briefing_date"] is None
+
+
+def test_deliver_prepared_briefing_success(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=8)
+    broadcasts = []
+    monkeypatch.setattr(briefing.ws_server, "broadcast", lambda msg: broadcasts.append(msg))
+    spoken = []
+
+    delivered = briefing.deliver_prepared_briefing("Good morning!", speak_fn=lambda t: spoken.append(t))
+
+    assert delivered is True
+    assert spoken == ["Good morning!"]
+    assert len(broadcasts) == 1
+    assert broadcasts[0]["type"] == "briefing"
+    assert broadcasts[0]["text"] == "Good morning!"
+    assert briefing._read_config()["last_briefing_date"] == "2026-07-12"
+
+
+def test_deliver_prepared_briefing_skips_if_already_delivered(monkeypatch, tmp_path):
+    # Guards the prefetch-thread race: text prepared early shouldn't be
+    # delivered twice if the other trigger site already delivered today's
+    # briefing in the meantime.
+    _isolate_config(monkeypatch, tmp_path)
+    _freeze_time(monkeypatch, hour=8)
+    briefing._write_config({"briefing_enabled": True, "last_briefing_date": "2026-07-12", "location": None})
+    spoken = []
+
+    delivered = briefing.deliver_prepared_briefing("Good morning!", speak_fn=lambda t: spoken.append(t))
+
+    assert delivered is False
+    assert spoken == []
+
+
+# --- maybe_deliver_briefing (all-in-one convenience wrapper) --------------------
 
 
 def test_maybe_deliver_briefing_noop_when_conditions_not_met(monkeypatch, tmp_path):
@@ -306,20 +563,19 @@ def test_maybe_deliver_briefing_full_success(monkeypatch, tmp_path):
     assert briefing._read_config()["last_briefing_date"] == "2026-07-12"
 
 
-def test_maybe_deliver_briefing_marks_done_even_if_gathering_fails(monkeypatch, tmp_path):
+def test_maybe_deliver_briefing_does_not_mark_done_if_gathering_fails(monkeypatch, tmp_path):
     _isolate_config(monkeypatch, tmp_path)
     _freeze_time(monkeypatch, hour=8)
-
-    def _boom():
-        raise RuntimeError("osascript exploded")
-
-    monkeypatch.setattr(briefing, "_get_todays_calendar_events", _boom)
+    monkeypatch.setattr(briefing, "_get_todays_calendar_events", lambda: (_ for _ in ()).throw(RuntimeError("osascript exploded")))
+    monkeypatch.setattr(briefing, "_get_due_reminders", lambda: "y")
+    monkeypatch.setattr(briefing, "_get_weather", lambda config: "z")
 
     delivered = briefing.maybe_deliver_briefing(speak_fn=lambda t: None)
 
     assert delivered is False
-    # Still marked as attempted for today -- no retry storm on every turn.
-    assert briefing._read_config()["last_briefing_date"] == "2026-07-12"
+    # Not marked as attempted -- allows a retry later today rather than
+    # permanently skipping it (see prepare_briefing_text's own test above).
+    assert briefing._read_config()["last_briefing_date"] is None
 
 
 def test_maybe_deliver_briefing_second_call_same_day_is_noop(monkeypatch, tmp_path):

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -277,12 +277,25 @@ function renderBriefing(text) {
 
   container.prepend(wrapper);
   expandPanel();
-  scrollTranscriptToBottom();
+  // Deliberately scrollTranscriptToTop, not …ToBottom: the briefing is
+  // prepended as the first thing in the panel, and on a shorter screen
+  // (smaller maxPanelHeight — see expandPanel) a multi-sentence briefing can
+  // be taller than the visible area. Scrolling to bottom (the normal
+  // behavior for a growing reply) would scroll straight past the label and
+  // opening sentences — found live from a real screenshot where exactly
+  // that happened, showing only the tail end of the message with no label
+  // visible at all.
+  scrollTranscriptToTop();
 }
 
 function scrollTranscriptToBottom() {
   const scroll = document.getElementById('transcript-scroll');
   scroll.scrollTop = scroll.scrollHeight;
+}
+
+function scrollTranscriptToTop() {
+  const scroll = document.getElementById('transcript-scroll');
+  scroll.scrollTop = 0;
 }
 
 // --- Tool activity ---

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -101,8 +101,7 @@ function handleSparkMessage(msg) {
       break;
 
     case 'briefing':
-      // Phase 6 feature — not wired up on the UI side yet.
-      console.log('[Spark UI] briefing', msg);
+      renderBriefing(msg.text);
       break;
 
     default:
@@ -244,6 +243,41 @@ function finalizeAssistantMessage() {
   }
   currentAssistantEl = null;
   highestSpokenIndex = -1;
+}
+
+// Arrives as one complete message (not streamed sentence-by-sentence like
+// assistant_chunk), and isn't a reply to anything the user said — rendered
+// as its own labeled bubble rather than reusing appendAssistantChunk's
+// streaming-cursor machinery, which assumes an in-progress reply.
+//
+// Prepended rather than clearing the container: the backend's other trigger
+// for this (first real utterance of the day, not just app launch — see
+// spark_whisper_mic.py) fires *after* that utterance's own transcript has
+// already been rendered, so clearing here would silently wipe the user's
+// just-shown message right before Spark's reply to it arrives. Prepending
+// keeps the briefing visually first (it was spoken first) without erasing
+// the exchange that triggered it.
+function renderBriefing(text) {
+  const container = getTranscriptContainer();
+  currentAssistantEl = null;
+  currentUserEl = null;
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'message assistant briefing';
+
+  const label = document.createElement('div');
+  label.className = 'briefing-label';
+  label.textContent = '🌅 Morning Briefing';
+  wrapper.appendChild(label);
+
+  const body = document.createElement('div');
+  body.className = 'sentence';
+  body.innerHTML = marked.parse(text);
+  wrapper.appendChild(body);
+
+  container.prepend(wrapper);
+  expandPanel();
+  scrollTranscriptToBottom();
 }
 
 function scrollTranscriptToBottom() {

--- a/public/style.css
+++ b/public/style.css
@@ -181,6 +181,16 @@ html, body {
   color: #f1f0f7;
 }
 
+.briefing-label {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #9c96c2;
+  margin-bottom: 6px;
+}
+
 .message.assistant .cursor {
   display: inline-block;
   width: 7px;


### PR DESCRIPTION
## Summary
- Adds a once-a-day morning briefing: calendar events + due/overdue reminders (via direct `osascript`, not routed through Claude's tool loop) + weather (Open-Meteo, keyless), composed into a short spoken summary by one Claude call.
- Triggers on app launch after 5am, or the first real utterance of the day for a long-running session that crosses midnight — whichever comes first, never more than once/day (`~/.spark/config.json`).
- Briefing gathering is prefetched on a background thread starting at process launch (before Whisper/Kokoro warmup and VAD calibration), so the network/IO-bound work overlaps with unavoidable startup time instead of stacking after it.
- Spark does not start listening (mic capture / typed-input processing) until the briefing has fully finished speaking — anything said earlier is safely queued and answered immediately once the briefing ends, rather than being silently ignored mid-briefing.
- Wires up the `briefing` WS message type and frontend rendering that have been scaffolded/stubbed since Phase 0.

## Root causes found and fixed during live testing
- **Calendar timeout (the big one):** two holiday-subscription calendars alone accounted for ~28 of an original ~46s wait — Calendar.app's `whose start date >= X` AppleScript filter isn't indexed, so it has to evaluate every occurrence of every recurring event (holiday calendars are the classic pathological case). Fixed by querying each calendar separately with its own timeout instead of one combined query. First attempt used concurrent queries and made things *worse* — Calendar.app appears to serialize Apple Events handling internally, so concurrent client requests contend with each other. Switched to sequential processing with a per-calendar timeout, an overall time budget, and holiday-named calendars deprioritized to the end of the queue. Net: ~46s worst case down to ~20s, with real calendars now actually succeeding instead of the whole section timing out.
- **Panel showing no label:** `renderBriefing()` was scrolling to the bottom like a normal streaming reply, but the briefing is prepended as the first thing in the panel — on a screen where the panel height caps below the content height, that scrolled straight past the label and opening sentences. Fixed with a dedicated scroll-to-top.
- **Listening started before the briefing finished:** mic/typed-input threads used to start before briefing delivery, so anything said during that window sat unanswered until the briefing finished, reading as Spark ignoring the user and barging in. Moved briefing delivery to before those threads start.

## Test plan
- [x] 110/110 backend unit tests pass (`pytest tests/`)
- [x] Live-verified end-to-end: launch → prefetch overlaps startup → briefing gathered, composed, delivered, and rendered with a labeled panel bubble
- [x] Live-verified the once-per-day gate (second interaction the same day does not repeat it)
- [x] Live-verified graceful degradation (a mid-run calendar timeout composed a summary from whatever data was available instead of failing entirely)
- [x] Live-verified with precise timing that a message sent before the briefing was ready sits queued and gets answered the instant the briefing finishes, with no premature/confusing response

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>